### PR TITLE
feat(009): content migration — reference repo → NeoSwiss pages

### DIFF
--- a/contacto/index.html
+++ b/contacto/index.html
@@ -160,10 +160,10 @@
             <h3 class="axis__title" data-cms="contacto.servicios.s2_title" data-i18n="cont.servicios.s2_title">Roadmap</h3>
             <p class="axis__body" data-cms="contacto.servicios.s2_desc" data-i18n="cont.servicios.s2_desc">Definimos prioridades y un plan de ruta alineado con bootcamps, rutas y proyectos con IA.</p>
           </div>
-          <div class="axis x-card" role="button" tabindex="0">
-            <span class="axis__label">03</span>
-            <h3 class="axis__title" data-cms="contacto.servicios.s3_title" data-i18n="cont.servicios.s3_title">Documento</h3>
-            <p class="axis__body" data-cms="contacto.servicios.s3_desc" data-i18n="cont.servicios.s3_desc">Recibes un Documento de Entendimiento con el mapa y las prioridades al finalizar.</p>
+          <div class="axis x-card" role="button" tabindex="0" style="border-color:var(--brand-gold);">
+            <span class="axis__label" style="color:var(--brand-gold);">03</span>
+            <h3 class="axis__title" data-cms="contacto.servicios.s3_title" data-i18n="cont.servicios.s3_title">Documento de Entendimiento</h3>
+            <p class="axis__body" data-cms="contacto.servicios.s3_desc" data-i18n="cont.servicios.s3_desc">Revisamos el contexto (retos, capacidades, urgencias, expectativas) y lo condensamos en un Documento que ordena el mapa y deja claro donde invertir primero y con que tipo de experiencia a medida.</p>
           </div>
         </div>
       </div>

--- a/empresas/index.html
+++ b/empresas/index.html
@@ -147,20 +147,30 @@
             <span class="tl-item__meta" data-i18n="emp.programas.s1_meta">Paso 01</span>
             <h3 class="tl-item__role" data-cms="empresas.programas.s1_title" data-i18n="emp.programas.s1_title">Diagnostico</h3>
             <span class="tl-item__org" data-i18n="emp.programas.s1_org">Sin Riesgo · 1 hora</span>
-            <p class="tl-item__impact" data-cms="empresas.programas.s1_desc">Identificamos brechas y fricciones manuales. Mapa de perdidas de tiempo y <strong>plan de accion inmediato</strong>.</p>
+            <p class="tl-item__impact" data-cms="empresas.programas.s1_desc" data-i18n-html="emp.programas.s1_desc">Identificamos brechas y fricciones manuales. Mapa de perdidas de tiempo y <strong>plan de accion inmediato</strong>.</p>
+            <span class="eyebrow" style="font-size:.6rem;margin-top:.5rem;color:#06b6d4;" data-i18n="emp.programas.s1_risk">Riesgo: $0</span>
           </article>
-          <article class="tl-item">
-            <span class="tl-item__meta" data-i18n="emp.programas.s2_meta">Paso 02</span>
+          <article class="tl-item" style="border-left-color:var(--brand-gold);">
+            <span class="tl-item__meta" style="color:var(--brand-gold);" data-i18n="emp.programas.s2_meta">Paso 02</span>
             <h3 class="tl-item__role" data-cms="empresas.programas.s2_title" data-i18n="emp.programas.s2_title">Workshop de Venta Amplificada</h3>
             <span class="tl-item__org" data-i18n="emp.programas.s2_org">Intensivo · 6 horas</span>
             <p class="tl-item__impact" data-cms="empresas.programas.s2_desc" data-i18n-html="emp.programas.s2_desc">Sistema comercial asistido por IA para <strong>acelerar pipeline velocity</strong> en su equipo.</p>
+            <span class="eyebrow" style="font-size:.6rem;margin-top:.5rem;color:var(--brand-gold);" data-i18n="emp.programas.s2_level">Exploración</span>
           </article>
           <article class="tl-item">
             <span class="tl-item__meta" data-i18n="emp.programas.s3_meta">Paso 03</span>
             <h3 class="tl-item__role" data-cms="empresas.programas.s3_title" data-i18n="emp.programas.s3_title">Bootcamp de Gestion Comercial con IA</h3>
             <span class="tl-item__org" data-i18n="emp.programas.s3_org">Inmersion · 18 horas</span>
             <p class="tl-item__impact" data-cms="empresas.programas.s3_desc" data-i18n-html="emp.programas.s3_desc">Formacion corporativa completa. Sistema <strong>replicable y escalable</strong> para equipos de alto rendimiento.</p>
+            <span class="eyebrow" style="font-size:.6rem;margin-top:.5rem;" data-i18n="emp.programas.s3_level">Compromiso Total</span>
           </article>
+        </div>
+
+        <!-- PyME Policy -->
+        <div style="text-align:center;margin-top:2rem;">
+          <span class="pill" style="display:inline-flex;align-items:center;gap:.5rem;padding:.5rem 1rem;border-radius:2rem;background:rgba(16,185,129,.1);border:1px solid rgba(16,185,129,.2);font-size:.75rem;color:#6ee7b7;" data-i18n-html="emp.pyme.text">
+            <strong>Acceso Universal:</strong> Empresas ≤ 10 empleados / ≤ 3 años pueden aspirar a Tarifa <a href="../personas/" style="text-decoration:underline;">Personas</a>. (Sujeto a validación).
+          </span>
         </div>
       </div>
     </section>

--- a/js/i18n/dictionaries/sidebar-labels.json
+++ b/js/i18n/dictionaries/sidebar-labels.json
@@ -30,6 +30,7 @@
     },
     "personas": {
       "autodiagnostico": { "es": "Autodiagnóstico", "en": "Self-assessment" },
+      "ruta_entrada": { "es": "Ruta de Entrada", "en": "Entry Path" },
       "recursos": { "es": "Recursos", "en": "Resources" },
       "programas": { "es": "Programas", "en": "Programs" },
       "comunidad": { "es": "Comunidad", "en": "Community" },

--- a/js/i18n/dictionaries/sidebar-labels.json
+++ b/js/i18n/dictionaries/sidebar-labels.json
@@ -38,6 +38,12 @@
       "casos": { "es": "Casos de éxito", "en": "Case studies" },
       "contacto": { "es": "Contacto", "en": "Contact" }
     },
+    "servicios": {
+      "workshops": { "es": "Workshops", "en": "Workshops" },
+      "bootcamps": { "es": "Bootcamps", "en": "Bootcamps" },
+      "programas": { "es": "Programas Élite", "en": "Elite Programs" },
+      "consultoria": { "es": "Consultoría", "en": "Consulting" }
+    },
     "programas": {
       "catalogo": { "es": "Catálogo", "en": "Catalog" },
       "detalle": { "es": "Detalle", "en": "Details" },

--- a/js/i18n/en.json
+++ b/js/i18n/en.json
@@ -1986,8 +1986,12 @@
       "s3_meta": "Step 03",
       "s3_title": "Commercial Management Bootcamp with AI",
       "s3_org": "Immersion · 18 hours",
+      "s1_desc": "We identify gaps and manual friction. Map of time losses and <strong>immediate action plan</strong>.",
+      "s1_risk": "Risk: $0",
       "s2_desc": "AI-assisted commercial system to <strong>accelerate pipeline velocity</strong> in your team.",
-      "s3_desc": "Complete corporate training. A <strong>replicable and scalable</strong> system for high-performance teams."
+      "s2_level": "Exploration",
+      "s3_desc": "Complete corporate training. A <strong>replicable and scalable</strong> system for high-performance teams.",
+      "s3_level": "Full Commitment"
     },
     "diagnostico": {
       "badge": "Diagnosis · 03",
@@ -2044,6 +2048,9 @@
       "badge": "Next step · 07",
       "lead": "No friction. Just strategic clarity. Schedule your no-risk diagnosis and receive a personalized roadmap.",
       "cta": "Schedule No-Risk Diagnosis →"
+    },
+    "pyme": {
+      "text": "<strong>Universal Access:</strong> Companies ≤ 10 employees / ≤ 3 years may qualify for <a href=\"../personas/\" style=\"text-decoration:underline;\">Individual</a> pricing. (Subject to validation)."
     }
   },
   "pers": {

--- a/js/i18n/en.json
+++ b/js/i18n/en.json
@@ -2506,5 +2506,124 @@
     "title": "Page not found",
     "body": "The page you're looking for doesn't exist or was moved. Go back to the homepage and explore everything MetodologIA has for you.",
     "cta": "Back to home →"
+  },
+  "vis": {
+    "hero": {
+      "badge": "The Science of Augmented Work",
+      "title": "<span style=\"color:var(--brand-gold)\">Method</span> + Technolog<span style=\"color:var(--brand-gold)\">y</span> = <span class=\"gradient-text\">Sovereignty</span>",
+      "description": "<strong>Spoiler alert:</strong> Technology without method is just speed in the wrong direction. We design systems for <strong style=\"color:var(--brand-gold)\">Digital, Professional and Strategic Sovereignty</strong>.",
+      "cta1": "Explore the System ↓",
+      "cta2": "Let's Talk"
+    },
+    "problema": {
+      "badge": "Diagnosis · 02",
+      "title": "The Operational <span style=\"color:#ef4444\">Fracture</span>",
+      "subtitle": "\"Chaos\" is not bad luck. It's a design flaw in your work system.",
+      "card1": {
+        "num": "01 · Critical Alert",
+        "title": "Chronic Multitasking",
+        "desc": "The silent killer of strategic depth. Each interruption costs 23 minutes of refocus."
+      },
+      "card2": {
+        "num": "02 · Resource Drain",
+        "title": "Repetitive Friction",
+        "desc": "Zombie tasks that drain senior talent. Your most valuable team spends 4 hours a day on copy-paste."
+      },
+      "card3": {
+        "num": "03 · Institutional Amnesia",
+        "title": "Information Silos",
+        "desc": "Knowledge trapped in chats, emails and heads. When someone leaves, they take everything."
+      },
+      "card4": {
+        "num": "04 · Tool Fallacy",
+        "title": "Cosmetic AI",
+        "desc": "Powerful tools, broken processes. Buying software doesn't fix a behavior problem."
+      }
+    },
+    "trampa": {
+      "badge": "The Trap · 03",
+      "title": "Chaos + <span style=\"color:var(--brand-gold)\">AI</span> = Chaos<sup style=\"color:var(--brand-gold)\">²</sup>",
+      "description": "Technology is an <strong>amplifier</strong>.<br>If your process is solid, it scales it.<br>If your process is garbage, <strong style=\"color:#ef4444\">it scales the garbage</strong>.",
+      "quote": "\"Believing that buying software will fix a behavior problem.\"",
+      "quote_author": "— The Tool Fallacy"
+    },
+    "sistema": {
+      "badge": "The System · 04",
+      "title": "The 4 Phases of <span class=\"gradient-text\">Sovereignty</span>",
+      "subtitle": "From reactive chaos to strategic design. Each phase builds on the previous one.",
+      "f1": {
+        "meta": "Phase 1 · Diagnosis",
+        "title": "GROUND",
+        "desc": "We map pains, flows and real opportunities. <strong>No assumptions</strong> — only measurable evidence."
+      },
+      "f2": {
+        "meta": "Phase 2 · Traction",
+        "title": "ACCELERATE",
+        "desc": "We eliminate friction and activate <strong>quick wins</strong>. The team feels the change in weeks, not months."
+      },
+      "f3": {
+        "meta": "Phase 3 · Systematization",
+        "title": "CATALYZE",
+        "desc": "We turn tacit knowledge into <strong>replicable digital assets</strong>. Playbooks, templates, agents."
+      },
+      "f4": {
+        "meta": "Phase 4 · Scale & Sovereignty",
+        "title": "AMPLIFY",
+        "desc": "Metodolog<span style=\"color:var(--brand-gold)\">IA</span> agents work <strong>24/7</strong> for you. You design, they execute."
+      }
+    },
+    "pivote": {
+      "badge": "Framework · 05",
+      "title": "Framework <span class=\"gradient-text\">P.I.V.O.T.E.</span>",
+      "subtitle": "Human First, <span style=\"color:var(--brand-gold)\">AI</span> Next. We clean the signal before amplifying it. Every decision is evaluated in this order — technology is <em>always</em> second to last.",
+      "phase_a": "Phase A · Ground",
+      "phase_b": "Phase B · Amplify",
+      "p": { "title": "People", "desc": "Mindset, roles and capabilities. Who decides, who executes, who learns?" },
+      "i": { "title": "Interactions", "desc": "Flows, friction and dependencies. Where is time, energy and context lost?" },
+      "v": { "title": "Value", "desc": "Measurable real impact. Which activities generate ROI and which are noise?" },
+      "o": { "title": "Organization", "desc": "Systematization and structure. Playbooks, SOPs and living knowledge base." },
+      "t": { "title": "Technology", "desc": "Automation and AI. Only after cleaning the signal do we amplify it." },
+      "e": { "title": "Evolution", "desc": "Continuous improvement. Metrics, retrospectives and data-driven pivoting." }
+    },
+    "principios": {
+      "badge": "Principles · 06",
+      "title": "What <span class=\"gradient-text\">Defines</span> Us",
+      "subtitle": "Four non-negotiable pillars of Metodolog<span style=\"color:var(--brand-gold)\">IA</span>.",
+      "metodo": {
+        "num": "01 · Method",
+        "title": "First order, then the tool.",
+        "desc": "If the process is broken, AI only scales the chaos. A clear method turns AI into leverage."
+      },
+      "soberania": {
+        "num": "02 · Sovereignty",
+        "title": "I finish when you no longer need me.",
+        "desc": "We build installed capacity, not dependency. Every engagement transfers explicit knowledge."
+      },
+      "dignidad": {
+        "num": "03 · Dignity",
+        "title": "Performance doesn't justify burnout.",
+        "desc": "Productivity without wellbeing is disguised exploitation. We design cadences with sustainable rhythm."
+      },
+      "evidencia": {
+        "num": "04 · Evidence",
+        "title": "Without data, there's no truth.",
+        "desc": "Everything we claim has a measurable before and after. CSAT, ROI, TTFW, Lead Time."
+      }
+    },
+    "resultado": {
+      "title": "The destination: <span class=\"gradient-text\">Strategic Sovereignty</span>",
+      "subtitle": "From reactive operator to impact designer. The systems work for you.",
+      "card1": { "title": "Free strategic hours", "desc": "Intelligent automation so your talent focuses on what matters." },
+      "card2": { "title": "Exponential growth", "desc": "Without increasing fixed costs. Agents multiply your delivery capacity." },
+      "card3": { "title": "Antifragile organization", "desc": "That learns continuously. Knowledge never leaves with people." }
+    },
+    "contacto": {
+      "badge": "Connect · 07",
+      "title": "Let's Accelerate your <span class=\"gradient-text\">Strateg<span style=\"color:var(--brand-gold)\">y</span></span>",
+      "lead": "No risk, no friction. 60 minutes to connect your pains and goals with real possibilities.",
+      "cta1": "Let's Talk →",
+      "cta2": "Explore Resources",
+      "response": "Response within 2 business days."
+    }
   }
 }

--- a/js/i18n/en.json
+++ b/js/i18n/en.json
@@ -1818,8 +1818,8 @@
       "s1_desc": "We map your pain points, goals and current context to understand your starting point.",
       "s2_title": "Roadmap",
       "s2_desc": "We define priorities and a route plan aligned with bootcamps, pathways and AI projects.",
-      "s3_title": "Document",
-      "s3_desc": "You receive an Understanding Document with the map and priorities at the end."
+      "s3_title": "Understanding Document",
+      "s3_desc": "We review the context (challenges, capabilities, urgencies, expectations) and condense it into a Document that maps out where to invest first and with what type of custom experience."
     },
     "ubicacion": {
       "badge": "Location · 03",

--- a/js/i18n/en.json
+++ b/js/i18n/en.json
@@ -2061,6 +2061,26 @@
       "cta_cotizador": "Design my Investment",
       "cta_programas": "View Programs ↓"
     },
+    "ruta": {
+      "badge": "Your First Step",
+      "title": "Entry <span class=\"gradient-text\">Path</span>",
+      "lead": "3 progressive steps. Start risk-free, advance at your pace.",
+      "s0_meta": "Step 0",
+      "s0_title": "Self-Assessment",
+      "s0_org": "No Risk · 1 hour",
+      "s0_desc": "We detect where you're losing time and money. <strong>First conversation at no cost</strong>.",
+      "s0_risk": "Risk: $0",
+      "s1_meta": "Step 1",
+      "s1_title": "Personal StrategIA Workshop",
+      "s1_org": "Coaching · 3 hours",
+      "s1_desc": "Define your roadmap. <strong>100% credited</strong> toward the Bootcamp.",
+      "s1_level": "Exploration",
+      "s2_meta": "Step 2",
+      "s2_title": "Professional Amplification Bootcamp",
+      "s2_org": "Immersion · 18 hours",
+      "s2_desc": "Master tools and become a <strong>Digital Champion</strong>.",
+      "s2_level": "Full Commitment"
+    },
     "recursos": {
       "badge": "Resources · 02",
       "title": "Resources for <span class=\"gradient-text\">Professionals</span>",
@@ -2103,7 +2123,8 @@
       "e2_meta": "Elite 02",
       "e2_title": "Digital Champions",
       "e2_org": "Elite · Advanced Program",
-      "e2_desc": "For leaders seeking to <strong>transform organizations</strong> from individual excellence."
+      "e2_desc": "For leaders seeking to <strong>transform organizations</strong> from individual excellence.",
+      "proximamente": "Coming Soon"
     },
     "comunidad": {
       "badge": "Community · 04",

--- a/js/i18n/es.json
+++ b/js/i18n/es.json
@@ -2506,5 +2506,124 @@
     "title": "Página no encontrada",
     "body": "La página que buscas no existe o fue movida. Vuelve al inicio y explora todo lo que MetodologIA tiene para ti.",
     "cta": "Volver al home →"
+  },
+  "vis": {
+    "hero": {
+      "badge": "La Ciencia del Trabajo Aumentado",
+      "title": "<span style=\"color:var(--brand-gold)\">Método</span> + Tecnolog<span style=\"color:var(--brand-gold)\">IA</span> = <span class=\"gradient-text\">Soberanía</span>",
+      "description": "<strong>Spoiler alert:</strong> La tecnología sin método es solo velocidad en la dirección equivocada. Diseñamos sistemas para la <strong style=\"color:var(--brand-gold)\">Soberanía Digital, Profesional y Estratégica</strong>.",
+      "cta1": "Explorar el Sistema ↓",
+      "cta2": "Conversemos"
+    },
+    "problema": {
+      "badge": "Diagnóstico · 02",
+      "title": "La <span style=\"color:#ef4444\">Fractura</span> <span class=\"gradient-text\">Operativa</span>",
+      "subtitle": "El \"caos\" no es mala suerte. Es un fallo de diseño en tu sistema de trabajo.",
+      "card1": {
+        "num": "01 · Alerta Crítica",
+        "title": "Multitasking Crónico",
+        "desc": "El asesino silencioso de la profundidad estratégica. Cada interrupción cuesta 23 minutos de refoco."
+      },
+      "card2": {
+        "num": "02 · Drenaje de Recursos",
+        "title": "Fricción Repetitiva",
+        "desc": "Tareas zombies que drenan talento senior. Tu equipo más valioso hace copy-paste 4 horas al día."
+      },
+      "card3": {
+        "num": "03 · Amnesia Institucional",
+        "title": "Silos de Información",
+        "desc": "Conocimiento atrapado en chats, correos y cabezas. Cuando alguien se va, se lleva todo."
+      },
+      "card4": {
+        "num": "04 · Falacia de Herramienta",
+        "title": "IA Cosmética",
+        "desc": "Herramientas potentes, procesos rotos. Comprar software no arregla un problema de comportamiento."
+      }
+    },
+    "trampa": {
+      "badge": "La Trampa · 03",
+      "title": "Caos + <span style=\"color:var(--brand-gold)\">IA</span> = Caos<sup style=\"color:var(--brand-gold)\">²</sup>",
+      "description": "La tecnología es un <strong>amplificador</strong>.<br>Si tu proceso es sólido, lo escala.<br>Si tu proceso es basura, <strong style=\"color:#ef4444\">escala la basura</strong>.",
+      "quote": "\"Creer que comprar software arreglará un problema de comportamiento.\"",
+      "quote_author": "— La Falacia de la Herramienta"
+    },
+    "sistema": {
+      "badge": "El Sistema · 04",
+      "title": "Las 4 Fases de la <span class=\"gradient-text\">Soberanía</span>",
+      "subtitle": "Del caos reactivo al diseño estratégico. Cada fase construye sobre la anterior.",
+      "f1": {
+        "meta": "Fase 1 · Diagnóstico",
+        "title": "FUNDAMENTAR",
+        "desc": "Mapeamos dolores, flujos y oportunidades reales. <strong>Sin supuestos</strong> — solo evidencia medible."
+      },
+      "f2": {
+        "meta": "Fase 2 · Tracción",
+        "title": "ACELERAR",
+        "desc": "Eliminamos fricción y activamos <strong>victorias rápidas</strong>. El equipo siente el cambio en semanas, no meses."
+      },
+      "f3": {
+        "meta": "Fase 3 · Sistematización",
+        "title": "CATALIZAR",
+        "desc": "Convertimos conocimiento tácito en <strong>activos digitales replicables</strong>. Playbooks, templates, agentes."
+      },
+      "f4": {
+        "meta": "Fase 4 · Escala & Soberanía",
+        "title": "AMPLIFICAR",
+        "desc": "Agentes de Metodolog<span style=\"color:var(--brand-gold)\">IA</span> trabajan <strong>24/7</strong> para ti. Tú diseñas, ellos ejecutan."
+      }
+    },
+    "pivote": {
+      "badge": "Framework · 05",
+      "title": "Framework <span class=\"gradient-text\">P.I.V.O.T.E.</span>",
+      "subtitle": "Human First, <span style=\"color:var(--brand-gold)\">IA</span> Next. Limpiamos la señal antes de amplificarla. Cada decisión se evalúa en este orden — la tecnología es <em>siempre</em> penúltima.",
+      "phase_a": "Fase A · Fundamentar",
+      "phase_b": "Fase B · Amplificar",
+      "p": { "title": "Personas", "desc": "Mindset, roles y capacidades. ¿Quién decide, quién ejecuta, quién aprende?" },
+      "i": { "title": "Interacciones", "desc": "Flujos, fricciones y dependencias. ¿Dónde se pierde tiempo, energía y contexto?" },
+      "v": { "title": "Valor", "desc": "Impacto real medible. ¿Qué actividades generan ROI y cuáles son ruido?" },
+      "o": { "title": "Organización", "desc": "Sistematización y estructura. Playbooks, SOPs y knowledge base viva." },
+      "t": { "title": "Tecnología", "desc": "Automatización e IA. Solo después de limpiar la señal, la amplificamos." },
+      "e": { "title": "Evolución", "desc": "Mejora continua. Métricas, retrospectivas y pivoteo basado en datos." }
+    },
+    "principios": {
+      "badge": "Principios · 06",
+      "title": "Lo que nos <span class=\"gradient-text\">Define</span>",
+      "subtitle": "Cuatro pilares innegociables de Metodolog<span style=\"color:var(--brand-gold)\">IA</span>.",
+      "metodo": {
+        "num": "01 · Método",
+        "title": "Primero el orden, después la herramienta.",
+        "desc": "Si el proceso está roto, la IA solo escala el caos. Un método claro convierte la IA en palanca."
+      },
+      "soberania": {
+        "num": "02 · Soberanía",
+        "title": "Termino cuando ya no me necesitas.",
+        "desc": "Construimos capacidad instalada, no dependencia. Cada engagement transfiere conocimiento explícito."
+      },
+      "dignidad": {
+        "num": "03 · Dignidad",
+        "title": "El rendimiento no justifica el desgaste.",
+        "desc": "Productividad sin bienestar es explotación disfrazada. Diseñamos cadencias con ritmo sostenible."
+      },
+      "evidencia": {
+        "num": "04 · Evidencia",
+        "title": "Sin datos, no hay verdad.",
+        "desc": "Todo lo que afirmamos tiene un antes y un después medible. CSAT, ROI, TTFW, Lead Time."
+      }
+    },
+    "resultado": {
+      "title": "El destino: <span class=\"gradient-text\">Soberanía Estratégica</span>",
+      "subtitle": "De operador reactivo a diseñador de impacto. Los sistemas trabajan para ti.",
+      "card1": { "title": "Liberas horas estratégicas", "desc": "Automatización inteligente para que tu talento se enfoque en lo que importa." },
+      "card2": { "title": "Crecimiento exponencial", "desc": "Sin aumentar costos fijos. Los agentes multiplican tu capacidad de entrega." },
+      "card3": { "title": "Organización antifrágil", "desc": "Que aprende de manera continua. El conocimiento nunca se va con las personas." }
+    },
+    "contacto": {
+      "badge": "Conectar · 07",
+      "title": "Aceleremos su <span class=\"gradient-text\">Estrateg<span style=\"color:var(--brand-gold)\">IA</span></span>",
+      "lead": "Sin riesgo, sin fricción. 60 minutos para conectar tus dolores y objetivos con las posibilidades reales.",
+      "cta1": "Conversemos →",
+      "cta2": "Explorar Recursos",
+      "response": "Respuesta en 2 días hábiles."
+    }
   }
 }

--- a/js/i18n/es.json
+++ b/js/i18n/es.json
@@ -1986,8 +1986,12 @@
       "s3_meta": "Paso 03",
       "s3_title": "Bootcamp de Gestion Comercial con IA",
       "s3_org": "Inmersion · 18 horas",
+      "s1_desc": "Identificamos brechas y fricciones manuales. Mapa de perdidas de tiempo y <strong>plan de accion inmediato</strong>.",
+      "s1_risk": "Riesgo: $0",
       "s2_desc": "Sistema comercial asistido por IA para <strong>acelerar pipeline velocity</strong> en su equipo.",
-      "s3_desc": "Formacion corporativa completa. Sistema <strong>replicable y escalable</strong> para equipos de alto rendimiento."
+      "s2_level": "Exploración",
+      "s3_desc": "Formacion corporativa completa. Sistema <strong>replicable y escalable</strong> para equipos de alto rendimiento.",
+      "s3_level": "Compromiso Total"
     },
     "diagnostico": {
       "badge": "Diagnostico · 03",
@@ -2044,6 +2048,9 @@
       "badge": "Siguiente paso · 07",
       "lead": "Sin friccion. Solo claridad estrategica. Agende su diagnostico sin riesgo y reciba un roadmap personalizado.",
       "cta": "Agendar Diagnostico Sin Riesgo →"
+    },
+    "pyme": {
+      "text": "<strong>Acceso Universal:</strong> Empresas ≤ 10 empleados / ≤ 3 años pueden aspirar a Tarifa <a href=\"../personas/\" style=\"text-decoration:underline;\">Personas</a>. (Sujeto a validación)."
     }
   },
   "pers": {

--- a/js/i18n/es.json
+++ b/js/i18n/es.json
@@ -2061,6 +2061,26 @@
       "cta_cotizador": "Disenar mi Inversion",
       "cta_programas": "Ver Programas ↓"
     },
+    "ruta": {
+      "badge": "Tu Primer Paso",
+      "title": "Ruta de <span class=\"gradient-text\">Entrada</span>",
+      "lead": "3 pasos progresivos. Empieza sin riesgo, avanza a tu ritmo.",
+      "s0_meta": "Step 0",
+      "s0_title": "Autodiagnóstico",
+      "s0_org": "Sin Riesgo · 1 hora",
+      "s0_desc": "Detectamos dónde estás perdiendo tiempo y dinero. <strong>Primera conversación sin costo</strong>.",
+      "s0_risk": "Riesgo: $0",
+      "s1_meta": "Step 1",
+      "s1_title": "Taller EstrategIA Personal",
+      "s1_org": "Coaching · 3 horas",
+      "s1_desc": "Define tu hoja de ruta. El <strong>100% se acredita</strong> al Bootcamp.",
+      "s1_level": "Exploración",
+      "s2_meta": "Step 2",
+      "s2_title": "Bootcamp Amplificación Profesional",
+      "s2_org": "Inmersión · 18 horas",
+      "s2_desc": "Domina herramientas y conviértete en <strong>Digital Champion</strong>.",
+      "s2_level": "Compromiso Total"
+    },
     "recursos": {
       "badge": "Recursos · 02",
       "title": "Recursos para <span class=\"gradient-text\">Profesionales</span>",
@@ -2103,7 +2123,8 @@
       "e2_meta": "Elite 02",
       "e2_title": "Digital Champions",
       "e2_org": "Elite · Programa avanzado",
-      "e2_desc": "Para lideres que buscan <strong>transformar organizaciones</strong> desde la excelencia individual."
+      "e2_desc": "Para lideres que buscan <strong>transformar organizaciones</strong> desde la excelencia individual.",
+      "proximamente": "Próximamente"
     },
     "comunidad": {
       "badge": "Comunidad · 04",

--- a/js/i18n/es.json
+++ b/js/i18n/es.json
@@ -1818,8 +1818,8 @@
       "s1_desc": "Mapeamos tus dolores, objetivos y contexto actual para entender tu punto de partida.",
       "s2_title": "Roadmap",
       "s2_desc": "Definimos prioridades y un plan de ruta alineado con bootcamps, rutas y proyectos con IA.",
-      "s3_title": "Documento",
-      "s3_desc": "Recibes un Documento de Entendimiento con el mapa y las prioridades al finalizar."
+      "s3_title": "Documento de Entendimiento",
+      "s3_desc": "Revisamos el contexto (retos, capacidades, urgencias, expectativas) y lo condensamos en un Documento que ordena el mapa y deja claro donde invertir primero y con que tipo de experiencia a medida."
     },
     "ubicacion": {
       "badge": "Ubicacion · 03",

--- a/js/sidebar/sections-config.js
+++ b/js/sidebar/sections-config.js
@@ -32,6 +32,7 @@ const SECTIONS = {
 
   personas: [
     { id: 'autodiagnostico', icon: 'scan-search', i18nKey: 'sidebar.personas.autodiagnostico' },
+    { id: 'ruta-entrada', icon: 'footprints', i18nKey: 'sidebar.personas.ruta_entrada' },
     { id: 'recursos', icon: 'book-open', i18nKey: 'sidebar.personas.recursos' },
     { id: 'programas', icon: 'graduation-cap', i18nKey: 'sidebar.personas.programas' },
     { id: 'comunidad', icon: 'heart-handshake', i18nKey: 'sidebar.personas.comunidad' },

--- a/js/sidebar/sections-config.js
+++ b/js/sidebar/sections-config.js
@@ -70,6 +70,13 @@ const SECTIONS = {
     { id: 'aplicar', icon: 'mail', i18nKey: 'sidebar.embajadores.aplicar' }
   ],
 
+  servicios: [
+    { id: 'workshops', icon: 'rocket', i18nKey: 'sidebar.servicios.workshops' },
+    { id: 'bootcamps', icon: 'zap', i18nKey: 'sidebar.servicios.bootcamps' },
+    { id: 'programas', icon: 'crown', i18nKey: 'sidebar.servicios.programas' },
+    { id: 'consultoria', icon: 'briefcase', i18nKey: 'sidebar.servicios.consultoria' }
+  ],
+
   ruta: [
     { id: 'diagnostico', icon: 'stethoscope', i18nKey: 'sidebar.ruta.diagnostico' },
     { id: 'fundamentar', icon: 'compass', i18nKey: 'sidebar.ruta.fundamentar' },

--- a/personas/index.html
+++ b/personas/index.html
@@ -111,6 +111,43 @@
       </div>
     </section>
 
+    <!-- ══════ 1.5 · RUTA DE ENTRADA ══════ -->
+    <section class="section" id="ruta-entrada">
+      <div class="container">
+        <span class="eyebrow" data-i18n="pers.ruta.badge">Tu Primer Paso</span>
+        <h2 class="h2" style="margin:1rem 0 .5rem;" data-i18n-html="pers.ruta.title">
+          Ruta de <span class="gradient-text">Entrada</span>
+        </h2>
+        <p class="lead" style="margin-bottom:1.5rem;" data-i18n="pers.ruta.lead">
+          3 pasos progresivos. Empieza sin riesgo, avanza a tu ritmo.
+        </p>
+
+        <div class="timeline">
+          <article class="tl-item">
+            <span class="tl-item__meta" style="color:#10b981;" data-i18n="pers.ruta.s0_meta">Step 0</span>
+            <h3 class="tl-item__role" data-i18n="pers.ruta.s0_title">Autodiagnóstico</h3>
+            <span class="tl-item__org" data-i18n="pers.ruta.s0_org">Sin Riesgo · 1 hora</span>
+            <p class="tl-item__impact" data-i18n-html="pers.ruta.s0_desc">Detectamos dónde estás perdiendo tiempo y dinero. <strong>Primera conversación sin costo</strong>.</p>
+            <span class="eyebrow" style="font-size:.6rem;margin-top:.5rem;color:#10b981;" data-i18n="pers.ruta.s0_risk">Riesgo: $0</span>
+          </article>
+          <article class="tl-item" style="border-left-color:var(--brand-gold);">
+            <span class="tl-item__meta" style="color:#3b82f6;" data-i18n="pers.ruta.s1_meta">Step 1</span>
+            <h3 class="tl-item__role" data-i18n="pers.ruta.s1_title">Taller EstrategIA Personal</h3>
+            <span class="tl-item__org" data-i18n="pers.ruta.s1_org">Coaching · 3 horas</span>
+            <p class="tl-item__impact" data-i18n-html="pers.ruta.s1_desc">Define tu hoja de ruta. El <strong>100% se acredita</strong> al Bootcamp.</p>
+            <span class="eyebrow" style="font-size:.6rem;margin-top:.5rem;color:#3b82f6;" data-i18n="pers.ruta.s1_level">Exploración</span>
+          </article>
+          <article class="tl-item">
+            <span class="tl-item__meta" style="color:var(--brand-gold);" data-i18n="pers.ruta.s2_meta">Step 2</span>
+            <h3 class="tl-item__role" data-i18n="pers.ruta.s2_title">Bootcamp Amplificación Profesional</h3>
+            <span class="tl-item__org" data-i18n="pers.ruta.s2_org">Inmersión · 18 horas</span>
+            <p class="tl-item__impact" data-i18n-html="pers.ruta.s2_desc">Domina herramientas y conviértete en <strong>Digital Champion</strong>.</p>
+            <span class="eyebrow" style="font-size:.6rem;margin-top:.5rem;color:var(--brand-gold);" data-i18n="pers.ruta.s2_level">Compromiso Total</span>
+          </article>
+        </div>
+      </div>
+    </section>
+
     <!-- ══════ 02 · RECURSOS ══════ -->
     <section class="section" id="recursos">
       <div class="container">
@@ -187,17 +224,19 @@
             <span class="tl-item__org" data-i18n="pers.programas.org_tactico">Tactico · 18h</span>
             <p class="tl-item__impact" data-cms="personas.programas.b4_desc" data-i18n-html="pers.programas.b4_desc">Aprende a tomar decisiones con <strong>datos y analisis IA</strong>.</p>
           </article>
-          <article class="tl-item">
+          <article class="tl-item" style="opacity:.7;">
             <span class="tl-item__meta" data-i18n="pers.programas.b5_meta">Bootcamp 05</span>
             <h3 class="tl-item__role" data-cms="personas.programas.b5_title" data-i18n="pers.programas.b5_title">Marca Personal Digital</h3>
             <span class="tl-item__org" data-i18n="pers.programas.org_tactico">Tactico · 18h</span>
             <p class="tl-item__impact" data-cms="personas.programas.b5_desc" data-i18n-html="pers.programas.b5_desc">Construye tu <strong>presencia digital</strong> con estrategia y herramientas IA.</p>
+            <span class="eyebrow" style="font-size:.6rem;margin-top:.5rem;color:#06b6d4;" data-i18n="pers.programas.proximamente">Próximamente</span>
           </article>
-          <article class="tl-item">
+          <article class="tl-item" style="opacity:.7;">
             <span class="tl-item__meta" data-i18n="pers.programas.b6_meta">Bootcamp 06</span>
             <h3 class="tl-item__role" data-cms="personas.programas.b6_title" data-i18n="pers.programas.b6_title">Automatizacion Profesional</h3>
             <span class="tl-item__org" data-i18n="pers.programas.org_tactico">Tactico · 18h</span>
             <p class="tl-item__impact" data-cms="personas.programas.b6_desc" data-i18n-html="pers.programas.b6_desc">Disena flujos de trabajo <strong>automatizados</strong> para tu practica profesional.</p>
+            <span class="eyebrow" style="font-size:.6rem;margin-top:.5rem;color:#06b6d4;" data-i18n="pers.programas.proximamente">Próximamente</span>
           </article>
           <article class="tl-item">
             <span class="tl-item__meta" data-i18n="pers.programas.e1_meta">Elite 01</span>

--- a/servicios/index.html
+++ b/servicios/index.html
@@ -6,7 +6,7 @@
   @poweredBy Pristino Agent
 -->
 <!DOCTYPE html>
-<html lang="es" class="scroll-smooth">
+<html lang="es" data-page-slug="servicios">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -67,18 +67,9 @@
     <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Poppins:wght@600;700;900&family=Montserrat:wght@400;600&display=swap" onload="this.onload=null;this.rel='stylesheet'">
     <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Poppins:wght@600;700;900&family=Montserrat:wght@400;600&display=swap"></noscript>
     
-    <!-- Critical CSS (Inlined for FCP) -->
-    <style>
-    :root{--font-primary:'Poppins',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;--font-secondary:'Montserrat',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;--font-tertiary:'Jost','Futura','Trebuchet MS',Arial,sans-serif;--bg-primary:#0a0f1e;--bg-surface:#131b2e;--bg-elevated:rgba(19,27,46,0.6);--bg-hover:rgba(36,48,70,0.7);--card-aspect-ratio:4/3;--image-aspect-ratio:16/9;--fallback-font-scale:0.95;--text-primary:#FFFFFF;--text-secondary:#e2e8f0;--text-muted:#f1f5f9;--border-subtle:rgba(255,255,255,0.08);--border-default:rgba(255,255,255,0.15);--border-strong:rgba(255,255,255,0.25);--brand-gold:var(--brand-gold);--brand-gold-dark:var(--brand-gold-dark);--brand-gold-glow:rgba(255,240,51,0.2);--brand-yellow:#fbbf24;--brand-yellow-dark:#d97706;--brand-red:#ef4444;--brand-emerald:#34d399;--brand-cyan:#22d3ee;--brand-purple:#8b5cf6;--brand-blue:#3b82f6;--brand-blue-dark:#2563eb;--gradient-gold:linear-gradient(135deg,var(--brand-gold) 0%,var(--brand-gold-dark) 100%);--gradient-premium:linear-gradient(135deg,#0B2545 0%,#1E3A5F 100%);--gradient-surface:linear-gradient(135deg,#0f172a 0%,#020617 100%)}
-    body{background-color:var(--bg-primary);color:var(--text-secondary);overflow-x:hidden;font-family:var(--font-secondary);margin:0;line-height:1.5}h1,h2,h3,h4,h5,h6,.nav-link,.premium-nav,.nav-logo-link h1{font-family:var(--font-primary);color:var(--text-primary)!important}.modal-content,.card-glass{font-family:var(--font-tertiary)}.container-max{max-width:80rem;margin:0 auto;padding:0 1.5rem}@media(min-width:1080px){.container{max-width:1080px}}html{scroll-behavior:smooth}.font-primary{font-family:var(--font-primary)}.font-secondary{font-family:var(--font-secondary)}.font-heading{font-family:var(--font-primary)}
-    </style>
-    <link rel="stylesheet"  media="print" onload="this.media='all'">
-    <noscript><link rel="stylesheet" ></noscript>
-    
-    <!-- Tailwind (Local Build) -->
     <link rel="stylesheet" href="../estilos/neoswiss-system.css?v=4">
     <link rel="stylesheet" href="../estilos/home.css?v=4">
-  <link rel="stylesheet" href="../../estilos/triple-toggle.css?v=4">
+    <link rel="stylesheet" href="../estilos/triple-toggle.css?v=4">
 
 
     
@@ -87,38 +78,28 @@
     
     
     <link rel="icon" type="image/svg+xml" href="../favicon.svg">
-    
-<script type="importmap">{"imports":{"firebase/app":"https://www.gstatic.com/firebasejs/10.14.0/firebase-app.js","firebase/firestore":"https://www.gstatic.com/firebasejs/10.14.0/firebase-firestore.js"}}</script>
+    <link rel="apple-touch-icon" href="../favicon.svg">
+
+    <script type="importmap">
+      {
+        "imports": {
+          "idb": "https://cdn.jsdelivr.net/npm/idb/build/index.js",
+          "firebase/app": "https://www.gstatic.com/firebasejs/10.14.0/firebase-app.js",
+          "firebase/firestore": "https://www.gstatic.com/firebasejs/10.14.0/firebase-firestore.js"
+        }
+      }
+    </script>
+
+    <script>const t=localStorage.getItem('mdg_theme');if(t==='light')document.documentElement.dataset.theme='light';const l=localStorage.getItem('mdg_locale')||localStorage.getItem('lang');if(l==='en')document.documentElement.lang='en';</script>
 </head>
-<body >
-<div class="bg-mesh" aria-hidden="true"></div>
+<body>
+  <div class="bg-mesh" aria-hidden="true"></div>
+  <a href="#main" class="sr-only" data-i18n="skip_link">Saltar al contenido</a>
 
-<!-- NAV -->
-<!-- PREMIUM NAVIGATION: Neural Command Center -->
-    <site-header base-path=".."></site-header>
+  <site-header></site-header>
+  <site-sidebar data-page="servicios"></site-sidebar>
 
-    <!-- Main Content -->
-    <main id="main-content" class="relative min-h-screen flex flex-col overflow-hidden">
-        
-        <!-- Golden Layout: Quote & Breadcrumb -->
-        <section class="hook-quote-section">
-            <div class="hook-quote-divider"></div>
-            <div class="hook-quote-content">
-                <p class="hook-quote-text" data-i18n="servicios.quote.text">"La formación es el único activo que no se deprecia en la era de la IA"</p>
-            </div>
-        </section>
-
-        <nav class="breadcrumb-nav">
-            <ol class="breadcrumb-list">
-                <li class="breadcrumb-item">
-                    <a href="../index.html" data-i18n="servicios.breadcrumb.home">Inicio</a>
-                </li>
-                <li class="breadcrumb-separator">/</li>
-                <li class="breadcrumb-item active" data-i18n="servicios.breadcrumb.current">Servicios</li>
-            </ol>
-        </nav>
-
-        <div class="layout-space"></div>
+  <main id="main" class="main">
 
 <!-- HERO -->
 <section class="relative min-h-[50vh] flex items-center pt-32 lg:pt-48 bg-gradient-to-b from-slate-900 via-slate-900/95 to-slate-900 overflow-hidden">
@@ -428,14 +409,12 @@
     </div>
 </section>
 
-</main>
-<triple-toggle></triple-toggle>
-<offline-pill></offline-pill>
-<consent-banner></consent-banner>
-<site-footer></site-footer>
+  </main>
 
-<!-- FOOTER -->
-<site-footer base-path=".."></site-footer>
+  <triple-toggle></triple-toggle>
+  <offline-pill></offline-pill>
+  <consent-banner></consent-banner>
+  <site-footer></site-footer>
 
 <!-- MODAL -->
 <div id="info-modal" class="modal-overlay" role="dialog" aria-modal="true" aria-labelledby="info-modal-heading">
@@ -659,19 +638,19 @@ function openModal(key) {
              </span>
         </a>
     `;
-    ModalSystem.open('info-modal');
-    if (typeof icons !== 'undefined') icons.createIcons();
+    document.getElementById('info-modal').classList.add('active');
 }
 
 function closeModal() {
-    ModalSystem.close('info-modal');
+    document.getElementById('info-modal').classList.remove('active');
 }
-
-document.addEventListener('DOMContentLoaded', () => {
-    if (typeof icons !== 'undefined') icons.createIcons();
-});
 </script>
 
-<script type="module">import{initShell}from'../js/blueprint/shell.js?v=4';initShell({pageSlug:'servicios'});</script>
+  <script type="module">
+    import { initShell } from '../js/blueprint/shell.js?v=4';
+    import { hydratePage } from '../js/cms/hydrate-page.js?v=4';
+    initShell({ pageSlug: 'servicios' });
+    hydratePage('servicios');
+  </script>
 </body>
 </html>

--- a/vision/index.html
+++ b/vision/index.html
@@ -69,17 +69,17 @@
     <!-- ══════ 01 · HERO ══════ -->
     <section class="section" id="hero">
       <div class="container" style="text-align:center;">
-        <span class="eyebrow" data-cms="vision.hero.badge">La Ciencia del Trabajo Aumentado</span>
-        <h1 class="h1" style="margin:1rem auto;max-width:48rem;" data-cms="vision.hero.title">
+        <span class="eyebrow" data-cms="vision.hero.badge" data-i18n="vis.hero.badge">La Ciencia del Trabajo Aumentado</span>
+        <h1 class="h1" style="margin:1rem auto;max-width:48rem;" data-cms="vision.hero.title" data-i18n-html="vis.hero.title">
           <span style="color:var(--brand-gold)">Método</span> + Tecnolog<span style="color:var(--brand-gold)">IA</span> = <span class="gradient-text">Soberanía</span>
         </h1>
-        <p class="lead" style="max-width:40rem;margin:0 auto 2rem;" data-cms="vision.hero.description">
+        <p class="lead" style="max-width:40rem;margin:0 auto 2rem;" data-cms="vision.hero.description" data-i18n-html="vis.hero.description">
           <strong>Spoiler alert:</strong> La tecnología sin método es solo velocidad en la dirección equivocada.
           Diseñamos sistemas para la <strong style="color:var(--brand-gold)">Soberanía Digital, Profesional y Estratégica</strong>.
         </p>
         <div class="home-hero__ctas">
-          <a href="#problema" class="home-cta home-cta--primary">Explorar el Sistema ↓</a>
-          <a href="/contacto/" class="home-cta home-cta--secondary">Conversemos</a>
+          <a href="#problema" class="home-cta home-cta--primary" data-i18n="vis.hero.cta1">Explorar el Sistema ↓</a>
+          <a href="/contacto/" class="home-cta home-cta--secondary" data-i18n="vis.hero.cta2">Conversemos</a>
         </div>
       </div>
     </section>
@@ -87,34 +87,34 @@
     <!-- ══════ 02 · PROBLEMA: La Fractura Operativa ══════ -->
     <section class="section" id="problema">
       <div class="container">
-        <span class="eyebrow">Diagnóstico · 02</span>
-        <h2 class="h2" style="margin:1rem 0 .5rem;" data-cms="vision.problema.title">
+        <span class="eyebrow" data-i18n="vis.problema.badge">Diagnóstico · 02</span>
+        <h2 class="h2" style="margin:1rem 0 .5rem;" data-cms="vision.problema.title" data-i18n-html="vis.problema.title">
           La <span style="color:#ef4444">Fractura</span> <span class="gradient-text">Operativa</span>
         </h2>
-        <p class="lead" style="margin-bottom:1.5rem;" data-cms="vision.problema.subtitle">
+        <p class="lead" style="margin-bottom:1.5rem;" data-cms="vision.problema.subtitle" data-i18n="vis.problema.subtitle">
           El "caos" no es mala suerte. Es un fallo de diseño en tu sistema de trabajo.
         </p>
 
         <div class="principles">
           <div class="principle x-card" role="button" tabindex="0">
-            <span class="principle__num">01 · Alerta Crítica</span>
-            <h3 class="principle__title" data-cms="vision.problema.card1.title">Multitasking Crónico</h3>
-            <p class="principle__body" data-cms="vision.problema.card1.desc">El asesino silencioso de la profundidad estratégica. Cada interrupción cuesta 23 minutos de refoco.</p>
+            <span class="principle__num" data-i18n="vis.problema.card1.num">01 · Alerta Crítica</span>
+            <h3 class="principle__title" data-cms="vision.problema.card1.title" data-i18n="vis.problema.card1.title">Multitasking Crónico</h3>
+            <p class="principle__body" data-cms="vision.problema.card1.desc" data-i18n="vis.problema.card1.desc">El asesino silencioso de la profundidad estratégica. Cada interrupción cuesta 23 minutos de refoco.</p>
           </div>
           <div class="principle x-card" role="button" tabindex="0">
-            <span class="principle__num">02 · Drenaje de Recursos</span>
-            <h3 class="principle__title" data-cms="vision.problema.card2.title">Fricción Repetitiva</h3>
-            <p class="principle__body" data-cms="vision.problema.card2.desc">Tareas zombies que drenan talento senior. Tu equipo más valioso hace copy-paste 4 horas al día.</p>
+            <span class="principle__num" data-i18n="vis.problema.card2.num">02 · Drenaje de Recursos</span>
+            <h3 class="principle__title" data-cms="vision.problema.card2.title" data-i18n="vis.problema.card2.title">Fricción Repetitiva</h3>
+            <p class="principle__body" data-cms="vision.problema.card2.desc" data-i18n="vis.problema.card2.desc">Tareas zombies que drenan talento senior. Tu equipo más valioso hace copy-paste 4 horas al día.</p>
           </div>
           <div class="principle x-card" role="button" tabindex="0">
-            <span class="principle__num">03 · Amnesia Institucional</span>
-            <h3 class="principle__title" data-cms="vision.problema.card3.title">Silos de Información</h3>
-            <p class="principle__body" data-cms="vision.problema.card3.desc">Conocimiento atrapado en chats, correos y cabezas. Cuando alguien se va, se lleva todo.</p>
+            <span class="principle__num" data-i18n="vis.problema.card3.num">03 · Amnesia Institucional</span>
+            <h3 class="principle__title" data-cms="vision.problema.card3.title" data-i18n="vis.problema.card3.title">Silos de Información</h3>
+            <p class="principle__body" data-cms="vision.problema.card3.desc" data-i18n="vis.problema.card3.desc">Conocimiento atrapado en chats, correos y cabezas. Cuando alguien se va, se lleva todo.</p>
           </div>
           <div class="principle x-card" role="button" tabindex="0">
-            <span class="principle__num">04 · Falacia de Herramienta</span>
-            <h3 class="principle__title" data-cms="vision.problema.card4.title">IA Cosmética</h3>
-            <p class="principle__body" data-cms="vision.problema.card4.desc">Herramientas potentes, procesos rotos. Comprar software no arregla un problema de comportamiento.</p>
+            <span class="principle__num" data-i18n="vis.problema.card4.num">04 · Falacia de Herramienta</span>
+            <h3 class="principle__title" data-cms="vision.problema.card4.title" data-i18n="vis.problema.card4.title">IA Cosmética</h3>
+            <p class="principle__body" data-cms="vision.problema.card4.desc" data-i18n="vis.problema.card4.desc">Herramientas potentes, procesos rotos. Comprar software no arregla un problema de comportamiento.</p>
           </div>
         </div>
       </div>
@@ -123,24 +123,24 @@
     <!-- ══════ 03 · TRAMPA: Caos² ══════ -->
     <section class="section" id="trampa">
       <div class="container">
-        <span class="eyebrow">La Trampa · 03</span>
-        <h2 class="h2" style="margin:1rem 0 .5rem;" data-cms="vision.trampa.title">
+        <span class="eyebrow" data-i18n="vis.trampa.badge">La Trampa · 03</span>
+        <h2 class="h2" style="margin:1rem 0 .5rem;" data-cms="vision.trampa.title" data-i18n-html="vis.trampa.title">
           Caos + <span style="color:var(--brand-gold)">IA</span> = Caos<sup style="color:var(--brand-gold)">²</sup>
         </h2>
 
         <div style="display:grid;grid-template-columns:1fr 1fr;gap:1.5rem;max-width:48rem;margin:1.5rem auto;" class="vision-equation">
           <div class="principle x-card" style="text-align:center;">
-            <p class="lead" data-cms="vision.trampa.description">
+            <p class="lead" data-cms="vision.trampa.description" data-i18n-html="vis.trampa.description">
               La tecnología es un <strong>amplificador</strong>.<br>
               Si tu proceso es sólido, lo escala.<br>
               Si tu proceso es basura, <strong style="color:#ef4444">escala la basura</strong>.
             </p>
           </div>
           <div class="principle x-card" style="border-left:3px solid var(--brand-gold);">
-            <blockquote style="font-style:italic;color:var(--brand-text-soft);" data-cms="vision.trampa.quote">
+            <blockquote style="font-style:italic;color:var(--brand-text-soft);" data-cms="vision.trampa.quote" data-i18n="vis.trampa.quote">
               "Creer que comprar software arreglará un problema de comportamiento."
             </blockquote>
-            <p style="font-size:.75rem;margin-top:.75rem;color:var(--brand-gold);" data-cms="vision.trampa.quote_author">
+            <p style="font-size:.75rem;margin-top:.75rem;color:var(--brand-gold);" data-cms="vision.trampa.quote_author" data-i18n="vis.trampa.quote_author">
               — La Falacia de la Herramienta
             </p>
           </div>
@@ -156,34 +156,34 @@
     <!-- ══════ 04 · SISTEMA: Las 4 Fases ══════ -->
     <section class="section" id="sistema">
       <div class="container">
-        <span class="eyebrow">El Sistema · 04</span>
-        <h2 class="h2" style="margin:1rem 0 .5rem;" data-cms="vision.sistema.title">
+        <span class="eyebrow" data-i18n="vis.sistema.badge">El Sistema · 04</span>
+        <h2 class="h2" style="margin:1rem 0 .5rem;" data-cms="vision.sistema.title" data-i18n-html="vis.sistema.title">
           Las 4 Fases de la <span class="gradient-text">Soberanía</span>
         </h2>
-        <p class="lead" style="margin-bottom:1.5rem;" data-cms="vision.sistema.subtitle">
+        <p class="lead" style="margin-bottom:1.5rem;" data-cms="vision.sistema.subtitle" data-i18n="vis.sistema.subtitle">
           Del caos reactivo al diseño estratégico. Cada fase construye sobre la anterior.
         </p>
 
         <div class="timeline">
           <article class="tl-item x-card" role="button" tabindex="0">
-            <span class="tl-item__meta" style="color:#ef4444;">Fase 1 · Diagnóstico</span>
-            <h3 class="tl-item__role" data-cms="vision.sistema.f1.title">FUNDAMENTAR</h3>
-            <p class="tl-item__impact" data-cms="vision.sistema.f1.desc">Mapeamos dolores, flujos y oportunidades reales. <strong>Sin supuestos</strong> — solo evidencia medible.</p>
+            <span class="tl-item__meta" style="color:#ef4444;" data-i18n="vis.sistema.f1.meta">Fase 1 · Diagnóstico</span>
+            <h3 class="tl-item__role" data-cms="vision.sistema.f1.title" data-i18n="vis.sistema.f1.title">FUNDAMENTAR</h3>
+            <p class="tl-item__impact" data-cms="vision.sistema.f1.desc" data-i18n-html="vis.sistema.f1.desc">Mapeamos dolores, flujos y oportunidades reales. <strong>Sin supuestos</strong> — solo evidencia medible.</p>
           </article>
           <article class="tl-item x-card" role="button" tabindex="0">
-            <span class="tl-item__meta" style="color:#f97316;">Fase 2 · Tracción</span>
-            <h3 class="tl-item__role" data-cms="vision.sistema.f2.title">ACELERAR</h3>
-            <p class="tl-item__impact" data-cms="vision.sistema.f2.desc">Eliminamos fricción y activamos <strong>victorias rápidas</strong>. El equipo siente el cambio en semanas, no meses.</p>
+            <span class="tl-item__meta" style="color:#f97316;" data-i18n="vis.sistema.f2.meta">Fase 2 · Tracción</span>
+            <h3 class="tl-item__role" data-cms="vision.sistema.f2.title" data-i18n="vis.sistema.f2.title">ACELERAR</h3>
+            <p class="tl-item__impact" data-cms="vision.sistema.f2.desc" data-i18n-html="vis.sistema.f2.desc">Eliminamos fricción y activamos <strong>victorias rápidas</strong>. El equipo siente el cambio en semanas, no meses.</p>
           </article>
           <article class="tl-item x-card" role="button" tabindex="0">
-            <span class="tl-item__meta" style="color:#06b6d4;">Fase 3 · Sistematización</span>
-            <h3 class="tl-item__role" data-cms="vision.sistema.f3.title">CATALIZAR</h3>
-            <p class="tl-item__impact" data-cms="vision.sistema.f3.desc">Convertimos conocimiento tácito en <strong>activos digitales replicables</strong>. Playbooks, templates, agentes.</p>
+            <span class="tl-item__meta" style="color:#06b6d4;" data-i18n="vis.sistema.f3.meta">Fase 3 · Sistematización</span>
+            <h3 class="tl-item__role" data-cms="vision.sistema.f3.title" data-i18n="vis.sistema.f3.title">CATALIZAR</h3>
+            <p class="tl-item__impact" data-cms="vision.sistema.f3.desc" data-i18n-html="vis.sistema.f3.desc">Convertimos conocimiento tácito en <strong>activos digitales replicables</strong>. Playbooks, templates, agentes.</p>
           </article>
           <article class="tl-item x-card" role="button" tabindex="0" style="border-left-color:var(--brand-gold);">
-            <span class="tl-item__meta" style="color:var(--brand-gold);">Fase 4 · Escala & Soberanía</span>
-            <h3 class="tl-item__role" data-cms="vision.sistema.f4.title">AMPLIFICAR</h3>
-            <p class="tl-item__impact" data-cms="vision.sistema.f4.desc">Agentes de Metodolog<span style="color:var(--brand-gold)">IA</span> trabajan <strong>24/7</strong> para ti. Tú diseñas, ellos ejecutan.</p>
+            <span class="tl-item__meta" style="color:var(--brand-gold);" data-i18n="vis.sistema.f4.meta">Fase 4 · Escala & Soberanía</span>
+            <h3 class="tl-item__role" data-cms="vision.sistema.f4.title" data-i18n="vis.sistema.f4.title">AMPLIFICAR</h3>
+            <p class="tl-item__impact" data-cms="vision.sistema.f4.desc" data-i18n-html="vis.sistema.f4.desc">Agentes de Metodolog<span style="color:var(--brand-gold)">IA</span> trabajan <strong>24/7</strong> para ti. Tú diseñas, ellos ejecutan.</p>
           </article>
         </div>
       </div>
@@ -192,52 +192,52 @@
     <!-- ══════ 05 · PIVOTE: El Framework ══════ -->
     <section class="section" id="pivote">
       <div class="container">
-        <span class="eyebrow">Framework · 05</span>
-        <h2 class="h2" style="margin:1rem 0 .5rem;" data-cms="vision.pivote.title">
+        <span class="eyebrow" data-i18n="vis.pivote.badge">Framework · 05</span>
+        <h2 class="h2" style="margin:1rem 0 .5rem;" data-cms="vision.pivote.title" data-i18n-html="vis.pivote.title">
           Framework <span class="gradient-text">P.I.V.O.T.E.</span>
         </h2>
-        <p class="lead" style="margin-bottom:1.5rem;" data-cms="vision.pivote.subtitle">
+        <p class="lead" style="margin-bottom:1.5rem;" data-cms="vision.pivote.subtitle" data-i18n-html="vis.pivote.subtitle">
           Human First, <span style="color:var(--brand-gold)">IA</span> Next. Limpiamos la señal antes de amplificarla.
           Cada decisión se evalúa en este orden — la tecnología es <em>siempre</em> penúltima.
         </p>
 
         <!-- Fase A: Fundamentar -->
-        <p class="muted" style="font-size:10px;font-weight:700;letter-spacing:.2em;text-transform:uppercase;margin-bottom:.75rem;">Fase A · Fundamentar</p>
+        <p class="muted" style="font-size:10px;font-weight:700;letter-spacing:.2em;text-transform:uppercase;margin-bottom:.75rem;" data-i18n="vis.pivote.phase_a">Fase A · Fundamentar</p>
         <div class="axes">
           <div class="axis x-card" role="button" tabindex="0">
             <span class="axis__label">P</span>
-            <h3 class="axis__title" data-cms="vision.pivote.p.title">Personas</h3>
-            <p class="axis__body" data-cms="vision.pivote.p.desc">Mindset, roles y capacidades. ¿Quién decide, quién ejecuta, quién aprende?</p>
+            <h3 class="axis__title" data-cms="vision.pivote.p.title" data-i18n="vis.pivote.p.title">Personas</h3>
+            <p class="axis__body" data-cms="vision.pivote.p.desc" data-i18n="vis.pivote.p.desc">Mindset, roles y capacidades. ¿Quién decide, quién ejecuta, quién aprende?</p>
           </div>
           <div class="axis x-card" role="button" tabindex="0">
             <span class="axis__label">I</span>
-            <h3 class="axis__title" data-cms="vision.pivote.i.title">Interacciones</h3>
-            <p class="axis__body" data-cms="vision.pivote.i.desc">Flujos, fricciones y dependencias. ¿Dónde se pierde tiempo, energía y contexto?</p>
+            <h3 class="axis__title" data-cms="vision.pivote.i.title" data-i18n="vis.pivote.i.title">Interacciones</h3>
+            <p class="axis__body" data-cms="vision.pivote.i.desc" data-i18n="vis.pivote.i.desc">Flujos, fricciones y dependencias. ¿Dónde se pierde tiempo, energía y contexto?</p>
           </div>
           <div class="axis x-card" role="button" tabindex="0">
             <span class="axis__label">V</span>
-            <h3 class="axis__title" data-cms="vision.pivote.v.title">Valor</h3>
-            <p class="axis__body" data-cms="vision.pivote.v.desc">Impacto real medible. ¿Qué actividades generan ROI y cuáles son ruido?</p>
+            <h3 class="axis__title" data-cms="vision.pivote.v.title" data-i18n="vis.pivote.v.title">Valor</h3>
+            <p class="axis__body" data-cms="vision.pivote.v.desc" data-i18n="vis.pivote.v.desc">Impacto real medible. ¿Qué actividades generan ROI y cuáles son ruido?</p>
           </div>
         </div>
 
         <!-- Fase B: Amplificar -->
-        <p class="muted" style="font-size:10px;font-weight:700;letter-spacing:.2em;text-transform:uppercase;margin:1.5rem 0 .75rem;">Fase B · Amplificar</p>
+        <p class="muted" style="font-size:10px;font-weight:700;letter-spacing:.2em;text-transform:uppercase;margin:1.5rem 0 .75rem;" data-i18n="vis.pivote.phase_b">Fase B · Amplificar</p>
         <div class="axes">
           <div class="axis x-card" role="button" tabindex="0">
             <span class="axis__label">O</span>
-            <h3 class="axis__title" data-cms="vision.pivote.o.title">Organización</h3>
-            <p class="axis__body" data-cms="vision.pivote.o.desc">Sistematización y estructura. Playbooks, SOPs y knowledge base viva.</p>
+            <h3 class="axis__title" data-cms="vision.pivote.o.title" data-i18n="vis.pivote.o.title">Organización</h3>
+            <p class="axis__body" data-cms="vision.pivote.o.desc" data-i18n="vis.pivote.o.desc">Sistematización y estructura. Playbooks, SOPs y knowledge base viva.</p>
           </div>
           <div class="axis x-card" role="button" tabindex="0">
             <span class="axis__label">T</span>
-            <h3 class="axis__title" data-cms="vision.pivote.t.title">Tecnología</h3>
-            <p class="axis__body" data-cms="vision.pivote.t.desc">Automatización e IA. Solo después de limpiar la señal, la amplificamos.</p>
+            <h3 class="axis__title" data-cms="vision.pivote.t.title" data-i18n="vis.pivote.t.title">Tecnología</h3>
+            <p class="axis__body" data-cms="vision.pivote.t.desc" data-i18n="vis.pivote.t.desc">Automatización e IA. Solo después de limpiar la señal, la amplificamos.</p>
           </div>
           <div class="axis x-card" role="button" tabindex="0">
             <span class="axis__label">E</span>
-            <h3 class="axis__title" data-cms="vision.pivote.e.title">Evolución</h3>
-            <p class="axis__body" data-cms="vision.pivote.e.desc">Mejora continua. Métricas, retrospectivas y pivoteo basado en datos.</p>
+            <h3 class="axis__title" data-cms="vision.pivote.e.title" data-i18n="vis.pivote.e.title">Evolución</h3>
+            <p class="axis__body" data-cms="vision.pivote.e.desc" data-i18n="vis.pivote.e.desc">Mejora continua. Métricas, retrospectivas y pivoteo basado en datos.</p>
           </div>
         </div>
       </div>
@@ -246,60 +246,60 @@
     <!-- ══════ 06 · PRINCIPIOS + RESULTADO ══════ -->
     <section class="section" id="principios">
       <div class="container">
-        <span class="eyebrow">Principios · 06</span>
-        <h2 class="h2" style="margin:1rem 0 .5rem;" data-cms="vision.principios.title">
+        <span class="eyebrow" data-i18n="vis.principios.badge">Principios · 06</span>
+        <h2 class="h2" style="margin:1rem 0 .5rem;" data-cms="vision.principios.title" data-i18n-html="vis.principios.title">
           Lo que nos <span class="gradient-text">Define</span>
         </h2>
-        <p class="lead" style="margin-bottom:1.5rem;" data-cms="vision.principios.subtitle">
+        <p class="lead" style="margin-bottom:1.5rem;" data-cms="vision.principios.subtitle" data-i18n-html="vis.principios.subtitle">
           Cuatro pilares innegociables de Metodolog<span style="color:var(--brand-gold)">IA</span>.
         </p>
 
         <div class="principles">
           <div class="principle x-card" role="button" tabindex="0">
-            <span class="principle__num">01 · Método</span>
-            <h3 class="principle__title" data-cms="vision.principios.metodo.title">Primero el orden, después la herramienta.</h3>
-            <p class="principle__body" data-cms="vision.principios.metodo.desc">Si el proceso está roto, la IA solo escala el caos. Un método claro convierte la IA en palanca.</p>
+            <span class="principle__num" data-i18n="vis.principios.metodo.num">01 · Método</span>
+            <h3 class="principle__title" data-cms="vision.principios.metodo.title" data-i18n="vis.principios.metodo.title">Primero el orden, después la herramienta.</h3>
+            <p class="principle__body" data-cms="vision.principios.metodo.desc" data-i18n="vis.principios.metodo.desc">Si el proceso está roto, la IA solo escala el caos. Un método claro convierte la IA en palanca.</p>
           </div>
           <div class="principle x-card" role="button" tabindex="0">
-            <span class="principle__num">02 · Soberanía</span>
-            <h3 class="principle__title" data-cms="vision.principios.soberania.title">Termino cuando ya no me necesitas.</h3>
-            <p class="principle__body" data-cms="vision.principios.soberania.desc">Construimos capacidad instalada, no dependencia. Cada engagement transfiere conocimiento explícito.</p>
+            <span class="principle__num" data-i18n="vis.principios.soberania.num">02 · Soberanía</span>
+            <h3 class="principle__title" data-cms="vision.principios.soberania.title" data-i18n="vis.principios.soberania.title">Termino cuando ya no me necesitas.</h3>
+            <p class="principle__body" data-cms="vision.principios.soberania.desc" data-i18n="vis.principios.soberania.desc">Construimos capacidad instalada, no dependencia. Cada engagement transfiere conocimiento explícito.</p>
           </div>
           <div class="principle x-card" role="button" tabindex="0">
-            <span class="principle__num">03 · Dignidad</span>
-            <h3 class="principle__title" data-cms="vision.principios.dignidad.title">El rendimiento no justifica el desgaste.</h3>
-            <p class="principle__body" data-cms="vision.principios.dignidad.desc">Productividad sin bienestar es explotación disfrazada. Diseñamos cadencias con ritmo sostenible.</p>
+            <span class="principle__num" data-i18n="vis.principios.dignidad.num">03 · Dignidad</span>
+            <h3 class="principle__title" data-cms="vision.principios.dignidad.title" data-i18n="vis.principios.dignidad.title">El rendimiento no justifica el desgaste.</h3>
+            <p class="principle__body" data-cms="vision.principios.dignidad.desc" data-i18n="vis.principios.dignidad.desc">Productividad sin bienestar es explotación disfrazada. Diseñamos cadencias con ritmo sostenible.</p>
           </div>
           <div class="principle x-card" role="button" tabindex="0">
-            <span class="principle__num">04 · Evidencia</span>
-            <h3 class="principle__title" data-cms="vision.principios.evidencia.title">Sin datos, no hay verdad.</h3>
-            <p class="principle__body" data-cms="vision.principios.evidencia.desc">Todo lo que afirmamos tiene un antes y un después medible. CSAT, ROI, TTFW, Lead Time.</p>
+            <span class="principle__num" data-i18n="vis.principios.evidencia.num">04 · Evidencia</span>
+            <h3 class="principle__title" data-cms="vision.principios.evidencia.title" data-i18n="vis.principios.evidencia.title">Sin datos, no hay verdad.</h3>
+            <p class="principle__body" data-cms="vision.principios.evidencia.desc" data-i18n="vis.principios.evidencia.desc">Todo lo que afirmamos tiene un antes y un después medible. CSAT, ROI, TTFW, Lead Time.</p>
           </div>
         </div>
 
         <!-- Resultado: Soberanía -->
-        <h3 class="h3" style="margin:2.5rem 0 1rem;text-align:center;" data-cms="vision.resultado.title">
+        <h3 class="h3" style="margin:2.5rem 0 1rem;text-align:center;" data-cms="vision.resultado.title" data-i18n-html="vis.resultado.title">
           El destino: <span class="gradient-text">Soberanía Estratégica</span>
         </h3>
-        <p class="lead" style="text-align:center;margin-bottom:1.5rem;" data-cms="vision.resultado.subtitle">
+        <p class="lead" style="text-align:center;margin-bottom:1.5rem;" data-cms="vision.resultado.subtitle" data-i18n="vis.resultado.subtitle">
           De operador reactivo a diseñador de impacto. Los sistemas trabajan para ti.
         </p>
 
         <div class="axes">
           <div class="axis x-card" style="text-align:center;">
             <span class="axis__label">Tiempo</span>
-            <h3 class="axis__title" data-cms="vision.resultado.card1.title">Liberas horas estratégicas</h3>
-            <p class="axis__body" data-cms="vision.resultado.card1.desc">Automatización inteligente para que tu talento se enfoque en lo que importa.</p>
+            <h3 class="axis__title" data-cms="vision.resultado.card1.title" data-i18n="vis.resultado.card1.title">Liberas horas estratégicas</h3>
+            <p class="axis__body" data-cms="vision.resultado.card1.desc" data-i18n="vis.resultado.card1.desc">Automatización inteligente para que tu talento se enfoque en lo que importa.</p>
           </div>
           <div class="axis x-card" style="text-align:center;border-color:var(--brand-gold);">
             <span class="axis__label" style="color:var(--brand-gold);">Escala</span>
-            <h3 class="axis__title" data-cms="vision.resultado.card2.title">Crecimiento exponencial</h3>
-            <p class="axis__body" data-cms="vision.resultado.card2.desc">Sin aumentar costos fijos. Los agentes multiplican tu capacidad de entrega.</p>
+            <h3 class="axis__title" data-cms="vision.resultado.card2.title" data-i18n="vis.resultado.card2.title">Crecimiento exponencial</h3>
+            <p class="axis__body" data-cms="vision.resultado.card2.desc" data-i18n="vis.resultado.card2.desc">Sin aumentar costos fijos. Los agentes multiplican tu capacidad de entrega.</p>
           </div>
           <div class="axis x-card" style="text-align:center;">
             <span class="axis__label">Cultura</span>
-            <h3 class="axis__title" data-cms="vision.resultado.card3.title">Organización antifrágil</h3>
-            <p class="axis__body" data-cms="vision.resultado.card3.desc">Que aprende de manera continua. El conocimiento nunca se va con las personas.</p>
+            <h3 class="axis__title" data-cms="vision.resultado.card3.title" data-i18n="vis.resultado.card3.title">Organización antifrágil</h3>
+            <p class="axis__body" data-cms="vision.resultado.card3.desc" data-i18n="vis.resultado.card3.desc">Que aprende de manera continua. El conocimiento nunca se va con las personas.</p>
           </div>
         </div>
       </div>
@@ -308,18 +308,18 @@
     <!-- ══════ 07 · CONTACTO CTA ══════ -->
     <section class="section" id="contacto">
       <div class="container" style="text-align:center;">
-        <span class="eyebrow">Conectar · 07</span>
-        <h2 class="h2" style="margin:1rem auto .5rem;max-width:40rem;" data-cms="vision.contacto.title">
+        <span class="eyebrow" data-i18n="vis.contacto.badge">Conectar · 07</span>
+        <h2 class="h2" style="margin:1rem auto .5rem;max-width:40rem;" data-cms="vision.contacto.title" data-i18n-html="vis.contacto.title">
           Aceleremos su <span class="gradient-text">Estrateg<span style="color:var(--brand-gold)">IA</span></span>
         </h2>
-        <p class="lead" style="max-width:36rem;margin:0 auto 2rem;" data-cms="vision.contacto.lead">
+        <p class="lead" style="max-width:36rem;margin:0 auto 2rem;" data-cms="vision.contacto.lead" data-i18n="vis.contacto.lead">
           Sin riesgo, sin fricción. 60 minutos para conectar tus dolores y objetivos con las posibilidades reales.
         </p>
         <div class="home-hero__ctas">
-          <a href="/contacto/" class="home-cta home-cta--primary">Conversemos →</a>
-          <a href="/recursos/" class="home-cta home-cta--secondary">Explorar Recursos</a>
+          <a href="/contacto/" class="home-cta home-cta--primary" data-i18n="vis.contacto.cta1">Conversemos →</a>
+          <a href="/recursos/" class="home-cta home-cta--secondary" data-i18n="vis.contacto.cta2">Explorar Recursos</a>
         </div>
-        <p class="muted" style="font-size:.85rem;margin-top:1rem;">Respuesta en 2 días hábiles.</p>
+        <p class="muted" style="font-size:.85rem;margin-top:1rem;" data-i18n="vis.contacto.response">Respuesta en 2 días hábiles.</p>
       </div>
     </section>
 


### PR DESCRIPTION
## Summary
- **Vision**: Added 86 `data-i18n` attributes + full `vis.*` ES/EN translations (was 0 i18n keys)
- **Empresas**: PyME exception policy pill + risk/commitment labels on funnel steps
- **Personas**: Step 0→1→2 entry pathway section + "Próximamente" badges on bootcamps 5-6
- **Contacto**: Enriched "Documento de Entendimiento" card with fuller reference description
- **Servicios**: Migrated to NeoSwiss shell (sidebar, anti-FOUC, fixed CSS path, removed legacy cruft)
- **Home**: Verified modal completeness — no content gaps vs reference

## Test plan
- [ ] JSON validation: `node -e "JSON.parse(...)"` on es.json, en.json, sidebar-labels.json
- [ ] Vision: locale toggle switches all 86 elements ES↔EN
- [ ] Empresas: PyME pill visible after programas section
- [ ] Personas: "Ruta de Entrada" section renders Step 0→1→2 timeline
- [ ] Servicios: sidebar scroll-spy works with 4 sections, modals open/close
- [ ] All pages: theme/locale/audience toggles functional

🤖 Generated with [Claude Code](https://claude.com/claude-code)