### PR TITLE
fix(009): remove 39 duplicate footers + unblock vision/servicios

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -28,7 +28,7 @@
     RewriteRule ^ruta/a-medida\.html$                   /contacto/     [R=301,L]
 
     # Directory-level redirects
-    RewriteRule ^servicios/(.*)$                        /programas/$1  [R=301,L]
+    # servicios/ redirect removed — page now serves its own NeoSwiss content
 
     # /ruta/ catch-all (after specific /ruta/ rules)
     RewriteRule ^ruta/(.*)$                             /diagnostico/  [R=301,L]

--- a/js/redirects/legacy-router.js
+++ b/js/redirects/legacy-router.js
@@ -10,8 +10,6 @@
 /** @type {Array<[string, string]>} Specific path → target pairs (checked before catch-all) */
 const REDIRECT_MAP = [
   ['/vision.html', '/metodo/'],
-  ['/vision/', '/metodo/'],
-  ['/servicios/', '/programas/'],
   ['/metodologia.html', '/metodo/'],
   ['/empresas/diagnostico-gratuito.html', '/diagnostico/?audiencia=empresa'],
   ['/personas/autodiagnostico.html', '/diagnostico/?audiencia=persona'],

--- a/recursos/a-medida/index.html
+++ b/recursos/a-medida/index.html
@@ -362,7 +362,6 @@
 <site-footer></site-footer>
 
     <!-- FOOTER -->
-    <site-footer base-path="../.."></site-footer>
 
     <script>
         document.addEventListener('DOMContentLoaded', () => {

--- a/recursos/automatizaciones/index.html
+++ b/recursos/automatizaciones/index.html
@@ -212,7 +212,6 @@
 <site-footer></site-footer>
 
     <!-- FOOTER -->
-    <site-footer base-path="../.."></site-footer>
 
     <script>
         // Init Icons

--- a/recursos/biblioteca-consulting/index.html
+++ b/recursos/biblioteca-consulting/index.html
@@ -43,7 +43,6 @@
 <offline-pill></offline-pill>
 <consent-banner></consent-banner>
 <site-footer></site-footer>
-<site-footer base-path="../.."></site-footer>
 <div id="modalOverlay" class="modal-overlay fixed inset-0 z-[10000] bg-slate-950/90 backdrop-blur-md flex items-center justify-center p-4" onclick="closeModal(event)"><div class="modal-content w-full max-w-3xl bg-[#0F1115] border border-white/10 rounded-2xl shadow-2xl flex flex-col max-h-[90vh] overflow-hidden"><div class="flex items-center justify-between p-5 border-b border-white/5"><div><span id="modalCategory" class="text-[10px] uppercase tracking-widest font-bold block opacity-70">Cat</span><h3 id="modalTitle" class="text-base font-bold text-white">Title</h3></div><button onclick="closeModal(null,true)" class="p-2 rounded-lg hover:bg-white/10 text-slate-400 hover:text-white"><i data-lucide="x" class="w-5 h-5"></i></button></div><div id="modalBody" class="p-5 overflow-y-auto flex-grow bg-slate-950/50"></div><div class="p-4 border-t border-white/5 flex justify-end"><button onclick="copyPrompt()" class="flex items-center gap-2 px-5 py-2.5 text-white font-bold rounded-xl text-sm" style="background:#f59e0b"><i data-lucide="copy" class="w-4 h-4"></i> <span data-i18n="biblioteca.modal_copy">Copiar</span></button></div></div></div>
 <script src="../../components/SiteHeader.js"></script><script src="../../components/SiteFooter.js"></script><script src="../../js/CTAHandler.js"></script>
 <script src="prompts_consulting.js"></script>

--- a/recursos/biblioteca-desarrollo/index.html
+++ b/recursos/biblioteca-desarrollo/index.html
@@ -43,7 +43,6 @@
 <offline-pill></offline-pill>
 <consent-banner></consent-banner>
 <site-footer></site-footer>
-<site-footer base-path="../.."></site-footer>
 <div id="modalOverlay" class="modal-overlay fixed inset-0 z-[10000] bg-slate-950/90 backdrop-blur-md flex items-center justify-center p-4" onclick="closeModal(event)"><div class="modal-content w-full max-w-3xl bg-[#0F1115] border border-white/10 rounded-2xl shadow-2xl flex flex-col max-h-[90vh] overflow-hidden"><div class="flex items-center justify-between p-5 border-b border-white/5"><div><span id="modalCategory" class="text-[10px] uppercase tracking-widest font-bold block opacity-70">Cat</span><h3 id="modalTitle" class="text-base font-bold text-white">Title</h3></div><button onclick="closeModal(null,true)" class="p-2 rounded-lg hover:bg-white/10 text-slate-400 hover:text-white"><i data-lucide="x" class="w-5 h-5"></i></button></div><div id="modalBody" class="p-5 overflow-y-auto flex-grow bg-slate-950/50"></div><div class="p-4 border-t border-white/5 flex justify-end"><button onclick="copyPrompt()" class="flex items-center gap-2 px-5 py-2.5 text-white font-bold rounded-xl text-sm" style="background:#06b6d4"><i data-lucide="copy" class="w-4 h-4"></i> <span data-i18n="biblioteca.modal_copy">Copiar</span></button></div></div></div>
 <script src="../../components/SiteHeader.js"></script><script src="../../components/SiteFooter.js"></script><script src="../../js/CTAHandler.js"></script>
 <script src="prompts_desarrollo.js"></script>

--- a/recursos/biblioteca-estrategia/index.html
+++ b/recursos/biblioteca-estrategia/index.html
@@ -43,7 +43,6 @@
 <offline-pill></offline-pill>
 <consent-banner></consent-banner>
 <site-footer></site-footer>
-<site-footer base-path="../.."></site-footer>
 <div id="modalOverlay" class="modal-overlay fixed inset-0 z-[10000] bg-slate-950/90 backdrop-blur-md flex items-center justify-center p-4" onclick="closeModal(event)"><div class="modal-content w-full max-w-3xl bg-[#0F1115] border border-white/10 rounded-2xl shadow-2xl flex flex-col max-h-[90vh] overflow-hidden"><div class="flex items-center justify-between p-5 border-b border-white/5"><div><span id="modalCategory" class="text-[10px] uppercase tracking-widest font-bold block opacity-70">Cat</span><h3 id="modalTitle" class="text-base font-bold text-white">Title</h3></div><button onclick="closeModal(null,true)" class="p-2 rounded-lg hover:bg-white/10 text-slate-400 hover:text-white"><i data-lucide="x" class="w-5 h-5"></i></button></div><div id="modalBody" class="p-5 overflow-y-auto flex-grow bg-slate-950/50"></div><div class="p-4 border-t border-white/5 flex justify-end"><button onclick="copyPrompt()" class="flex items-center gap-2 px-5 py-2.5 text-white font-bold rounded-xl text-sm" style="background:#3b82f6"><i data-lucide="copy" class="w-4 h-4"></i> <span data-i18n="biblioteca.modal_copy">Copiar</span></button></div></div></div>
 <script src="../../components/SiteHeader.js"></script><script src="../../components/SiteFooter.js"></script><script src="../../js/CTAHandler.js"></script>
 <script src="prompts_estrategia.js"></script>

--- a/recursos/biblioteca-marketing/index.html
+++ b/recursos/biblioteca-marketing/index.html
@@ -43,7 +43,6 @@
 <offline-pill></offline-pill>
 <consent-banner></consent-banner>
 <site-footer></site-footer>
-<site-footer base-path="../.."></site-footer>
 <div id="modalOverlay" class="modal-overlay fixed inset-0 z-[10000] bg-slate-950/90 backdrop-blur-md flex items-center justify-center p-4" onclick="closeModal(event)"><div class="modal-content w-full max-w-3xl bg-[#0F1115] border border-white/10 rounded-2xl shadow-2xl flex flex-col max-h-[90vh] overflow-hidden"><div class="flex items-center justify-between p-5 border-b border-white/5"><div><span id="modalCategory" class="text-[10px] uppercase tracking-widest font-bold block opacity-70">Cat</span><h3 id="modalTitle" class="text-base font-bold text-white">Title</h3></div><button onclick="closeModal(null,true)" class="p-2 rounded-lg hover:bg-white/10 text-slate-400 hover:text-white"><i data-lucide="x" class="w-5 h-5"></i></button></div><div id="modalBody" class="p-5 overflow-y-auto flex-grow bg-slate-950/50"></div><div class="p-4 border-t border-white/5 flex justify-end"><button onclick="copyPrompt()" class="flex items-center gap-2 px-5 py-2.5 text-white font-bold rounded-xl text-sm" style="background:#ec4899"><i data-lucide="copy" class="w-4 h-4"></i> <span data-i18n="biblioteca.modal_copy">Copiar</span></button></div></div></div>
 <script src="../../components/SiteHeader.js"></script><script src="../../components/SiteFooter.js"></script><script src="../../js/CTAHandler.js"></script>
 <script src="prompts_marketing.js"></script>

--- a/recursos/biblioteca-productos/index.html
+++ b/recursos/biblioteca-productos/index.html
@@ -43,7 +43,6 @@
 <offline-pill></offline-pill>
 <consent-banner></consent-banner>
 <site-footer></site-footer>
-<site-footer base-path="../.."></site-footer>
 <div id="modalOverlay" class="modal-overlay fixed inset-0 z-[10000] bg-slate-950/90 backdrop-blur-md flex items-center justify-center p-4" onclick="closeModal(event)"><div class="modal-content w-full max-w-3xl bg-[#0F1115] border border-white/10 rounded-2xl shadow-2xl flex flex-col max-h-[90vh] overflow-hidden"><div class="flex items-center justify-between p-5 border-b border-white/5"><div><span id="modalCategory" class="text-[10px] uppercase tracking-widest font-bold block opacity-70">Cat</span><h3 id="modalTitle" class="text-base font-bold text-white">Title</h3></div><button onclick="closeModal(null,true)" class="p-2 rounded-lg hover:bg-white/10 text-slate-400 hover:text-white"><i data-lucide="x" class="w-5 h-5"></i></button></div><div id="modalBody" class="p-5 overflow-y-auto flex-grow bg-slate-950/50"></div><div class="p-4 border-t border-white/5 flex justify-end"><button onclick="copyPrompt()" class="flex items-center gap-2 px-5 py-2.5 text-white font-bold rounded-xl text-sm" style="background:#8b5cf6"><i data-lucide="copy" class="w-4 h-4"></i> <span data-i18n="biblioteca.modal_copy">Copiar</span></button></div></div></div>
 <script src="../../components/SiteHeader.js"></script><script src="../../components/SiteFooter.js"></script><script src="../../js/CTAHandler.js"></script>
 <script src="prompts_productos.js"></script>

--- a/recursos/biblioteca-proyectos/index.html
+++ b/recursos/biblioteca-proyectos/index.html
@@ -43,7 +43,6 @@
 <offline-pill></offline-pill>
 <consent-banner></consent-banner>
 <site-footer></site-footer>
-<site-footer base-path="../.."></site-footer>
 <div id="modalOverlay" class="modal-overlay fixed inset-0 z-[10000] bg-slate-950/90 backdrop-blur-md flex items-center justify-center p-4" onclick="closeModal(event)"><div class="modal-content w-full max-w-3xl bg-[#0F1115] border border-white/10 rounded-2xl shadow-2xl flex flex-col max-h-[90vh] overflow-hidden"><div class="flex items-center justify-between p-5 border-b border-white/5"><div><span id="modalCategory" class="text-[10px] uppercase tracking-widest font-bold block opacity-70">Cat</span><h3 id="modalTitle" class="text-base font-bold text-white">Title</h3></div><button onclick="closeModal(null,true)" class="p-2 rounded-lg hover:bg-white/10 text-slate-400 hover:text-white"><i data-lucide="x" class="w-5 h-5"></i></button></div><div id="modalBody" class="p-5 overflow-y-auto flex-grow bg-slate-950/50"></div><div class="p-4 border-t border-white/5 flex justify-end"><button onclick="copyPrompt()" class="flex items-center gap-2 px-5 py-2.5 text-white font-bold rounded-xl text-sm" style="background:#f97316"><i data-lucide="copy" class="w-4 h-4"></i> <span data-i18n="biblioteca.modal_copy">Copiar</span></button></div></div></div>
 <script src="../../components/SiteHeader.js"></script><script src="../../components/SiteFooter.js"></script><script src="../../js/CTAHandler.js"></script>
 <script src="prompts_proyectos.js"></script>

--- a/recursos/biblioteca-ventas/index.html
+++ b/recursos/biblioteca-ventas/index.html
@@ -48,7 +48,6 @@
 <offline-pill></offline-pill>
 <consent-banner></consent-banner>
 <site-footer></site-footer>
-<site-footer base-path="../.."></site-footer>
 <div id="modalOverlay" class="modal-overlay fixed inset-0 z-[10000] bg-slate-950/90 backdrop-blur-md flex items-center justify-center p-4" onclick="closeModal(event)"><div class="modal-content w-full max-w-3xl bg-[#0F1115] border border-white/10 rounded-2xl shadow-2xl flex flex-col max-h-[90vh] overflow-hidden"><div class="flex items-center justify-between p-5 border-b border-white/5"><div><span id="modalCategory" class="text-[10px] uppercase tracking-widest font-bold block opacity-70">Cat</span><h3 id="modalTitle" class="text-base font-bold text-white">Title</h3></div><button onclick="closeModal(null,true)" class="p-2 rounded-lg hover:bg-white/10 text-slate-400 hover:text-white" title="Cerrar"><i data-lucide="x" class="w-5 h-5"></i></button></div><div id="modalBody" class="p-5 overflow-y-auto flex-grow bg-slate-950/50"></div><div class="p-4 border-t border-white/5 flex justify-end"><button onclick="copyPrompt()" class="flex items-center gap-2 px-5 py-2.5 text-white font-bold rounded-xl text-sm bg-brand-green"><i data-lucide="copy" class="w-4 h-4"></i> <span data-i18n="biblioteca.modal_copy">Copiar</span></button></div></div></div>
 <script src="../../components/SiteHeader.js"></script><script src="../../components/SiteFooter.js"></script><script src="../../js/CTAHandler.js"></script>
 <script src="prompts_ventas.js"></script>

--- a/recursos/biblioteca-vibe-coding/index.html
+++ b/recursos/biblioteca-vibe-coding/index.html
@@ -43,7 +43,6 @@
 <offline-pill></offline-pill>
 <consent-banner></consent-banner>
 <site-footer></site-footer>
-<site-footer base-path="../.."></site-footer>
 <div id="modalOverlay" class="modal-overlay fixed inset-0 z-[10000] bg-slate-950/90 backdrop-blur-md flex items-center justify-center p-4" onclick="closeModal(event)"><div class="modal-content w-full max-w-3xl bg-[#0F1115] border border-white/10 rounded-2xl shadow-2xl flex flex-col max-h-[90vh] overflow-hidden"><div class="flex items-center justify-between p-5 border-b border-white/5"><div><span id="modalCategory" class="text-[10px] uppercase tracking-widest font-bold block opacity-70">Cat</span><h3 id="modalTitle" class="text-base font-bold text-white">Title</h3></div><button onclick="closeModal(null,true)" class="p-2 rounded-lg hover:bg-white/10 text-slate-400 hover:text-white"><i data-lucide="x" class="w-5 h-5"></i></button></div><div id="modalBody" class="p-5 overflow-y-auto flex-grow bg-slate-950/50"></div><div class="p-4 border-t border-white/5 flex justify-end"><button onclick="copyPrompt()" class="flex items-center gap-2 px-5 py-2.5 text-white font-bold rounded-xl text-sm" style="background:#84cc16"><i data-lucide="copy" class="w-4 h-4"></i> <span data-i18n="biblioteca.modal_copy">Copiar</span></button></div></div></div>
 <script src="../../components/SiteHeader.js"></script><script src="../../components/SiteFooter.js"></script><script src="../../js/CTAHandler.js"></script>
 <script src="prompts_vibe_coding.js"></script>

--- a/recursos/catalogo/index.html
+++ b/recursos/catalogo/index.html
@@ -372,7 +372,6 @@
 <site-footer></site-footer>
 
     <!-- FOOTER -->
-    <site-footer base-path="../.."></site-footer>
 
     <script>
         document.addEventListener('DOMContentLoaded', () => {

--- a/recursos/ebooks/index.html
+++ b/recursos/ebooks/index.html
@@ -213,7 +213,6 @@
 <site-footer></site-footer>
 
     <!-- FOOTER -->
-    <site-footer base-path="../.."></site-footer>
 
     <script>
         // Init Icons

--- a/recursos/flujos-genspark/index.html
+++ b/recursos/flujos-genspark/index.html
@@ -213,7 +213,6 @@
 <site-footer></site-footer>
 
     <!-- FOOTER -->
-    <site-footer base-path="../.."></site-footer>
 
     <script>
         // Init Icons

--- a/recursos/flujos-manus/index.html
+++ b/recursos/flujos-manus/index.html
@@ -212,7 +212,6 @@
 <site-footer></site-footer>
 
     <!-- FOOTER -->
-    <site-footer base-path="../.."></site-footer>
 
     <script>
         // Init Icons

--- a/recursos/miniapps-aistudio/index.html
+++ b/recursos/miniapps-aistudio/index.html
@@ -213,7 +213,6 @@
 <site-footer></site-footer>
 
     <!-- FOOTER -->
-    <site-footer base-path="../.."></site-footer>
 
     <script>
         // Init Icons

--- a/recursos/miniapps-claude/index.html
+++ b/recursos/miniapps-claude/index.html
@@ -213,7 +213,6 @@
 <site-footer></site-footer>
 
     <!-- FOOTER -->
-    <site-footer base-path="../.."></site-footer>
 
     <script>
         // Init Icons

--- a/recursos/playbooks/index.html
+++ b/recursos/playbooks/index.html
@@ -212,7 +212,6 @@
 <site-footer></site-footer>
 
     <!-- FOOTER -->
-    <site-footer base-path="../.."></site-footer>
 
     <script>
         // Init Icons

--- a/recursos/playbooks/item-01/index.html
+++ b/recursos/playbooks/item-01/index.html
@@ -265,7 +265,6 @@
 <consent-banner></consent-banner>
 <site-footer></site-footer>
 
-    <site-footer base-path="../../.."></site-footer>
 
     <script>
         document.addEventListener('DOMContentLoaded', () => {

--- a/recursos/plugins-claude-code/index.html
+++ b/recursos/plugins-claude-code/index.html
@@ -223,7 +223,6 @@
 <consent-banner></consent-banner>
 <site-footer></site-footer>
 
-<site-footer base-path="../.."></site-footer>
 
 
 

--- a/recursos/premium/asistentes-gemini/index.html
+++ b/recursos/premium/asistentes-gemini/index.html
@@ -130,7 +130,6 @@
 <consent-banner></consent-banner>
 <site-footer></site-footer>
     <!-- Performance Optimization: Removal of Lucide script dependency -->
-<site-footer base-path="../../.."></site-footer>
 <script type="module">import{initShell}from'../../../js/blueprint/shell.js?v=4';initShell({pageSlug:'asistentes-gemini'});</script>
 </body>
 </html>

--- a/recursos/premium/asistentes-gpt/index.html
+++ b/recursos/premium/asistentes-gpt/index.html
@@ -131,7 +131,6 @@
 <consent-banner></consent-banner>
 <site-footer></site-footer>
     <!-- Performance Optimization: Removal of Lucide script dependency -->
-<site-footer base-path="../../.."></site-footer>
 <script type="module">import{initShell}from'../../../js/blueprint/shell.js?v=4';initShell({pageSlug:'asistentes-gpt'});</script>
 </body>
 </html>

--- a/recursos/premium/automatizaciones/index.html
+++ b/recursos/premium/automatizaciones/index.html
@@ -128,7 +128,6 @@
 <consent-banner></consent-banner>
 <site-footer></site-footer>
     <!-- Performance Optimization: Removal of Lucide script dependency -->
-<site-footer base-path="../../.."></site-footer>
 <script type="module">import{initShell}from'../../../js/blueprint/shell.js?v=4';initShell({pageSlug:'automatizaciones'});</script>
 </body>
 </html>

--- a/recursos/premium/catalogo/index.html
+++ b/recursos/premium/catalogo/index.html
@@ -363,7 +363,6 @@
 <site-footer></site-footer>
 
 <!-- Performance Optimization: Removal of Lucide script dependency -->
-<site-footer base-path="../../.."></site-footer>
 <script type="module">import{initShell}from'../../../js/blueprint/shell.js?v=4';initShell({pageSlug:'catalogo'});</script>
 </body>
 </html>

--- a/recursos/premium/ebooks/index.html
+++ b/recursos/premium/ebooks/index.html
@@ -130,7 +130,6 @@
 <consent-banner></consent-banner>
 <site-footer></site-footer>
     <!-- Performance Optimization: Removal of Lucide script dependency -->
-<site-footer base-path="../../.."></site-footer>
 <script type="module">import{initShell}from'../../../js/blueprint/shell.js?v=4';initShell({pageSlug:'ebooks'});</script>
 </body>
 </html>

--- a/recursos/premium/flujos-genspark/index.html
+++ b/recursos/premium/flujos-genspark/index.html
@@ -128,7 +128,6 @@
 <consent-banner></consent-banner>
 <site-footer></site-footer>
     <!-- Performance Optimization: Removal of Lucide script dependency -->
-<site-footer base-path="../../.."></site-footer>
 <script type="module">import{initShell}from'../../../js/blueprint/shell.js?v=4';initShell({pageSlug:'flujos-genspark'});</script>
 </body>
 </html>

--- a/recursos/premium/flujos-manus/index.html
+++ b/recursos/premium/flujos-manus/index.html
@@ -128,7 +128,6 @@
 <consent-banner></consent-banner>
 <site-footer></site-footer>
     <!-- Performance Optimization: Removal of Lucide script dependency -->
-<site-footer base-path="../../.."></site-footer>
 <script type="module">import{initShell}from'../../../js/blueprint/shell.js?v=4';initShell({pageSlug:'flujos-manus'});</script>
 </body>
 </html>

--- a/recursos/premium/index.html
+++ b/recursos/premium/index.html
@@ -420,7 +420,6 @@
 <site-footer></site-footer>
 
     <!-- FOOTER -->
-    <site-footer base-path="../.."></site-footer>
 
     <script>
         // Init Icons

--- a/recursos/premium/miniapps-aistudio/index.html
+++ b/recursos/premium/miniapps-aistudio/index.html
@@ -129,7 +129,6 @@
 <consent-banner></consent-banner>
 <site-footer></site-footer>
     <!-- Performance Optimization: Removal of Lucide script dependency -->
-<site-footer base-path="../../.."></site-footer>
 <script type="module">import{initShell}from'../../../js/blueprint/shell.js?v=4';initShell({pageSlug:'miniapps-aistudio'});</script>
 </body>
 </html>

--- a/recursos/premium/miniapps-claude/index.html
+++ b/recursos/premium/miniapps-claude/index.html
@@ -129,7 +129,6 @@
 <consent-banner></consent-banner>
 <site-footer></site-footer>
     <!-- Performance Optimization: Removal of Lucide script dependency -->
-<site-footer base-path="../../.."></site-footer>
 <script type="module">import{initShell}from'../../../js/blueprint/shell.js?v=4';initShell({pageSlug:'miniapps-claude'});</script>
 </body>
 </html>

--- a/recursos/premium/playbooks/index.html
+++ b/recursos/premium/playbooks/index.html
@@ -183,7 +183,6 @@
 <consent-banner></consent-banner>
 <site-footer></site-footer>
 
-    <site-footer base-path="../../.."></site-footer>
 
     <!-- Performance Optimization: Removal of Lucide script dependency -->
 <script type="module">import{initShell}from'../../../js/blueprint/shell.js?v=4';initShell({pageSlug:'playbooks'});</script>

--- a/recursos/premium/prototipos-stitch/index.html
+++ b/recursos/premium/prototipos-stitch/index.html
@@ -128,7 +128,6 @@
 <consent-banner></consent-banner>
 <site-footer></site-footer>
     <!-- Performance Optimization: Removal of Lucide script dependency -->
-<site-footer base-path="../../.."></site-footer>
 <script type="module">import{initShell}from'../../../js/blueprint/shell.js?v=4';initShell({pageSlug:'prototipos-stitch'});</script>
 </body>
 </html>

--- a/recursos/premium/prototipos-v0/index.html
+++ b/recursos/premium/prototipos-v0/index.html
@@ -120,7 +120,6 @@
 <consent-banner></consent-banner>
 <site-footer></site-footer>
     <!-- Performance Optimization: Removal of Lucide script dependency -->
-<site-footer base-path="../../.."></site-footer>
 <script type="module">import{initShell}from'../../../js/blueprint/shell.js?v=4';initShell({pageSlug:'prototipos-v0'});</script>
 </body>
 </html>

--- a/recursos/prototipos-stitch/index.html
+++ b/recursos/prototipos-stitch/index.html
@@ -212,7 +212,6 @@
 <site-footer></site-footer>
 
     <!-- FOOTER -->
-    <site-footer base-path="../.."></site-footer>
 
     <script>
         // Init Icons

--- a/recursos/prototipos-v0/index.html
+++ b/recursos/prototipos-v0/index.html
@@ -212,7 +212,6 @@
 <site-footer></site-footer>
 
     <!-- FOOTER -->
-    <site-footer base-path="../.."></site-footer>
 
     <script>
         // Init Icons

--- a/recursos/workflows/index.html
+++ b/recursos/workflows/index.html
@@ -200,7 +200,6 @@
 <site-footer></site-footer>
 
     <!-- FOOTER -->
-    <site-footer base-path="../.."></site-footer>
 
     <script>
         // Init Icons

--- a/recursos/workflows/wf-01/index.html
+++ b/recursos/workflows/wf-01/index.html
@@ -249,7 +249,6 @@ gantt
     <a href="wf-01-standalone.html" download class="btn-download btn-outline-dl">Descargar HTML</a>
 </div>
 
-<site-footer base-path="../../.."></site-footer>
 
 
 

--- a/recursos/workflows/wf-02/index.html
+++ b/recursos/workflows/wf-02/index.html
@@ -243,7 +243,6 @@ gantt
     <a href="wf-02-standalone.html" download class="btn-download btn-outline-dl">Descargar HTML</a>
 </div>
 
-<site-footer base-path="../../.."></site-footer>
 
 
 

--- a/recursos/workflows/wf-03/index.html
+++ b/recursos/workflows/wf-03/index.html
@@ -243,7 +243,6 @@ gantt
     <a href="wf-03-standalone.html" download class="btn-download btn-outline-dl">Descargar HTML</a>
 </div>
 
-<site-footer base-path="../../.."></site-footer>
 
 
 

--- a/recursos/workflows/wf-04/index.html
+++ b/recursos/workflows/wf-04/index.html
@@ -243,7 +243,6 @@ gantt
     <a href="wf-04-standalone.html" download class="btn-download btn-outline-dl">Descargar HTML</a>
 </div>
 
-<site-footer base-path="../../.."></site-footer>
 
 
 

--- a/tests/e2e/cert-01-core-pages.spec.js
+++ b/tests/e2e/cert-01-core-pages.spec.js
@@ -30,8 +30,8 @@ const CORE_PAGES = [
   { slug: 'legal',       path: '/legal/',                   name: 'Legal' },
   { slug: 'ruta',        path: '/ruta/',                    name: 'Ruta' },
   { slug: 'embajadores', path: '/nosotros/embajadores/',    name: 'Embajadores' },
-  { slug: 'vision',      path: '/vision/index.html',        name: 'Vision' },
-  { slug: 'servicios',   path: '/servicios/index.html',     name: 'Servicios' },
+  { slug: 'vision',      path: '/vision/',                   name: 'Vision' },
+  { slug: 'servicios',   path: '/servicios/',                name: 'Servicios' },
 ];
 
 for (const pg of CORE_PAGES) {

--- a/tests/e2e/content-migration-certification.spec.js
+++ b/tests/e2e/content-migration-certification.spec.js
@@ -94,7 +94,7 @@ test.describe('Phase 1: Vision — i18n Completeness', () => {
 
   test('AC-1.1: vision page has ≥80 data-i18n attributes', async ({ page }) => {
     // Arrange
-    await navigateTo(page, '/vision/index.html');
+    await navigateTo(page, '/vision/');
 
     // Act
     const i18nCount = await page.locator('[data-i18n], [data-i18n-html]').count();
@@ -105,7 +105,7 @@ test.describe('Phase 1: Vision — i18n Completeness', () => {
 
   test('AC-1.2: all 7 vision sections are present', async ({ page }) => {
     // Arrange
-    await navigateTo(page, '/vision/index.html');
+    await navigateTo(page, '/vision/');
 
     // Act + Assert (structural verification)
     const sectionIds = ['hero', 'problema', 'trampa', 'sistema', 'pivote', 'principios', 'contacto'];
@@ -122,7 +122,7 @@ test.describe('Phase 1: Vision — i18n Completeness', () => {
     await page.evaluate(() => {
       try { localStorage.removeItem('mdg_locale'); } catch {}
     }).catch(() => {});
-    await navigateTo(page, '/vision/index.html');
+    await navigateTo(page, '/vision/');
 
     // Act
     await switchToEN(page);
@@ -134,7 +134,7 @@ test.describe('Phase 1: Vision — i18n Completeness', () => {
 
   test('AC-1.4: zero raw i18n keys in EN mode', async ({ page }) => {
     // Arrange
-    await navigateTo(page, '/vision/index.html');
+    await navigateTo(page, '/vision/');
 
     // Act
     await switchToEN(page);
@@ -145,7 +145,7 @@ test.describe('Phase 1: Vision — i18n Completeness', () => {
 
   test('AC-1.5: PIVOTE framework shows 6 letters (P-I-V-O-T-E)', async ({ page }) => {
     // Arrange
-    await navigateTo(page, '/vision/index.html');
+    await navigateTo(page, '/vision/');
 
     // Act
     const axisLabels = page.locator('#pivote .axis__label');
@@ -162,7 +162,7 @@ test.describe('Phase 1: Vision — i18n Completeness', () => {
 
   test('AC-1.6: 4 problema cards render with translated nums', async ({ page }) => {
     // Arrange
-    await navigateTo(page, '/vision/index.html');
+    await navigateTo(page, '/vision/');
 
     // Act + Assert
     await assertMinCount(page, '#problema .principle', 4, 'problema cards');
@@ -173,7 +173,7 @@ test.describe('Phase 1: Vision — i18n Completeness', () => {
   });
   test('AC-1.7: vision modals open on card click', async ({ page }) => {
     // Arrange
-    await navigateTo(page, '/vision/index.html');
+    await navigateTo(page, '/vision/');
 
     // Act — click problema card 4 (IA Cosmética)
     await page.locator('#card-prob4').click();
@@ -195,7 +195,7 @@ test.describe('Phase 1: Vision — i18n Completeness', () => {
 
   test('AC-1.8: vision modal content is bilingual', async ({ page }) => {
     // Arrange
-    await navigateTo(page, '/vision/index.html');
+    await navigateTo(page, '/vision/');
     await switchToEN(page);
 
     // Act — click trampa quote card
@@ -211,7 +211,7 @@ test.describe('Phase 1: Vision — i18n Completeness', () => {
 
   test('AC-1.9: sidebar translates to EN on locale toggle', async ({ page }) => {
     // Arrange
-    await navigateTo(page, '/vision/index.html');
+    await navigateTo(page, '/vision/');
 
     // Act — wait for i18n, switch locale, then force sidebar re-render
     await page.waitForFunction(() => !!window.i18n?.setLang, { timeout: 5000 });
@@ -465,7 +465,7 @@ test.describe('Phase 5: Servicios — NeoSwiss Shell', () => {
 
   test('AC-5.1: page has data-page-slug="servicios"', async ({ page }) => {
     // Arrange
-    await navigateTo(page, '/servicios/index.html');
+    await navigateTo(page, '/servicios/');
 
     // Act
     const slug = await page.locator('html').getAttribute('data-page-slug');
@@ -476,7 +476,7 @@ test.describe('Phase 5: Servicios — NeoSwiss Shell', () => {
 
   test('AC-5.2: site-sidebar component is present', async ({ page }) => {
     // Arrange
-    await navigateTo(page, '/servicios/index.html');
+    await navigateTo(page, '/servicios/');
 
     // Act + Assert
     await expect(page.locator('site-sidebar')).toBeAttached();
@@ -486,7 +486,7 @@ test.describe('Phase 5: Servicios — NeoSwiss Shell', () => {
 
   test('AC-5.3: only ONE site-footer in DOM', async ({ page }) => {
     // Arrange
-    await navigateTo(page, '/servicios/index.html');
+    await navigateTo(page, '/servicios/');
 
     // Act
     const footerCount = await page.locator('site-footer').count();
@@ -497,7 +497,7 @@ test.describe('Phase 5: Servicios — NeoSwiss Shell', () => {
 
   test('AC-5.4: workshop modal opens and closes', async ({ page }) => {
     // Arrange
-    await navigateTo(page, '/servicios/index.html');
+    await navigateTo(page, '/servicios/');
 
     // Act — click first workshop card
     await page.locator('button[onclick*="ws01"]').click();
@@ -517,7 +517,7 @@ test.describe('Phase 5: Servicios — NeoSwiss Shell', () => {
 
   test('AC-5.5: all 4 service sections exist', async ({ page }) => {
     // Arrange
-    await navigateTo(page, '/servicios/index.html');
+    await navigateTo(page, '/servicios/');
 
     // Act + Assert
     const sectionIds = ['workshops', 'bootcamps', 'programas', 'consultoria'];
@@ -528,7 +528,7 @@ test.describe('Phase 5: Servicios — NeoSwiss Shell', () => {
 
   test('AC-5.6: 12 workshop cards rendered', async ({ page }) => {
     // Arrange
-    await navigateTo(page, '/servicios/index.html');
+    await navigateTo(page, '/servicios/');
 
     // Act
     const wsCards = page.locator('#workshops button[onclick*="openModal"]');
@@ -539,7 +539,7 @@ test.describe('Phase 5: Servicios — NeoSwiss Shell', () => {
 
   test('AC-5.7: 5 bootcamp cards rendered', async ({ page }) => {
     // Arrange
-    await navigateTo(page, '/servicios/index.html');
+    await navigateTo(page, '/servicios/');
 
     // Act
     const bcCards = page.locator('#bootcamps button[onclick*="openModal"]');
@@ -556,7 +556,7 @@ test.describe('Phase 5: Servicios — NeoSwiss Shell', () => {
     });
 
     // Act
-    await navigateTo(page, '/servicios/index.html');
+    await navigateTo(page, '/servicios/');
 
     // Assert
     expect(cssResponses.length).toBeGreaterThanOrEqual(1);
@@ -565,7 +565,7 @@ test.describe('Phase 5: Servicios — NeoSwiss Shell', () => {
 
   test('AC-5.9: skip-link for accessibility', async ({ page }) => {
     // Arrange
-    await navigateTo(page, '/servicios/index.html');
+    await navigateTo(page, '/servicios/');
 
     // Act + Assert
     await expect(page.locator('a.sr-only[href="#main"]')).toBeAttached();
@@ -629,14 +629,13 @@ test.describe('Phase 6: Home — Modal Completeness', () => {
 
 test.describe('Cross-Cutting: NeoSwiss Contract', () => {
 
-  // NOTE: /vision/ → /metodo/ and /servicios/ → /programas/ via legacy-router.js
   const PAGES = [
     { path: '/', slug: 'home', name: 'Home' },
     { path: '/empresas/', slug: 'empresas', name: 'Empresas' },
     { path: '/personas/', slug: 'personas', name: 'Personas' },
     { path: '/contacto/', slug: 'contacto', name: 'Contacto' },
-    { path: '/metodo/', slug: 'metodo', name: 'Metodo (ex-Vision)' },
-    { path: '/programas/', slug: 'programas', name: 'Programas (ex-Servicios)' },
+    { path: '/vision/', slug: 'vision', name: 'Vision' },
+    { path: '/servicios/', slug: 'servicios', name: 'Servicios' },
   ];
 
   for (const pg of PAGES) {


### PR DESCRIPTION
## Summary
- **39 duplicate `site-footer` removed** from sub-pages (shell.js auto-imports + hardcoded = 2 footers)
- **Vision page unblocked**: removed JS redirect /vision/→/metodo/, 7 sections + 20 modals now directly accessible
- **Servicios page unblocked**: removed JS+htaccess redirect /servicios/→/programas/, 23 service cards now accessible
- **Updated tests**: cert-01 + content-migration specs now use direct paths

## Test plan
- [x] `npx playwright test tests/e2e/cert-01-core-pages.spec.js` — 112/112 pass
- [x] Vision loads at /vision/ with PIVOTE modals functional
- [x] Servicios loads at /servicios/ with 12 WS + 5 BC + 2 Elite cards
- [x] Zero pages with duplicate site-footer

🤖 Generated with [Claude Code](https://claude.com/claude-code)