### PR TITLE
fix(009): sitemap 100% — 91/91 pages

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,7 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
         xmlns:xhtml="http://www.w3.org/1999/xhtml">
 
-  <!-- ══ CORE PAGES (priority 0.8-1.0) ══ -->
+  <!-- ══ CORE PAGES (priority 0.7-1.0) ══ -->
   <url>
     <loc>https://metodologia.info/</loc>
     <lastmod>2026-04-25</lastmod>
@@ -88,6 +88,18 @@
     <lastmod>2026-04-25</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://metodologia.info/vision/</loc>
+    <lastmod>2026-04-25</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
+  </url>
+  <url>
+    <loc>https://metodologia.info/servicios/</loc>
+    <lastmod>2026-04-25</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.7</priority>
   </url>
 
   <!-- ══ RECURSOS — FREE LISTINGS (priority 0.5) ══ -->


### PR DESCRIPTION
Added /vision/ and /servicios/ after redirect removal. 91/91 = 100%.